### PR TITLE
Trims input file contents for import_uplc

### DIFF
--- a/PlutusCore/UPLC/ScriptEncoding/Basic.lean
+++ b/PlutusCore/UPLC/ScriptEncoding/Basic.lean
@@ -225,48 +225,52 @@ def importUplcImp : CommandElab := fun stx => do
     let content ← liftM $ do
       let path := System.FilePath.mk filename
       IO.FS.readFile path
-    match decodeProgramFromByteString content with
+    let content' := String.trim content
+    match decodeProgramFromByteString content' with
     | .some p =>
         logInfo s!"Successfully decoded '{filename}'"
         return (toExpr p)
     | .none =>
-        throwError (decodingErrorWithSuggestion content `flat filename)
+        throwError (decodingErrorWithSuggestion content' `flat filename)
 
   /-- Parses a flat hex-encoded UPLC file and returns the resulting expression -/
   parseFlatHexUplc (filename : String) : TermElabM Expr := do
     let content ← liftM $ do
       let path := System.FilePath.mk filename
       IO.FS.readFile path
-    match flatEncodedScriptFromHex? content with
+    let content' := String.trim content
+    match flatEncodedScriptFromHex? content' with
     | .ok p =>
         logInfo s!"Successfully decoded flat hex '{filename}'"
         return (toExpr p)
     | .error msg =>
-        throwError (decodingErrorWithSuggestion content `flat_hex filename (some msg))
+        throwError (decodingErrorWithSuggestion content' `flat_hex filename (some msg))
 
   /-- Parses a single CBOR hex-encoded UPLC file and returns the resulting expression -/
   parseSingleCborHexUplc (filename : String) : TermElabM Expr := do
     let content ← liftM $ do
       let path := System.FilePath.mk filename
       IO.FS.readFile path
-    match singleCborEncodedScriptFromHex? content with
+    let content' := String.trim content
+    match singleCborEncodedScriptFromHex? content' with
     | .ok p =>
         logInfo s!"Successfully decoded single CBOR hex '{filename}'"
         return (toExpr p)
     | .error msg =>
-        throwError (decodingErrorWithSuggestion content `single_cbor_hex filename (some msg))
+        throwError (decodingErrorWithSuggestion content' `single_cbor_hex filename (some msg))
 
   /-- Parses a double CBOR hex-encoded UPLC file and returns the resulting expression -/
   parseDoubleCborHexUplc (filename : String) : TermElabM Expr := do
     let content ← liftM $ do
       let path := System.FilePath.mk filename
       IO.FS.readFile path
-    match doubleCborEncodedScriptFromHex? content with
+    let content' := String.trim content
+    match doubleCborEncodedScriptFromHex? content' with
     | .ok p =>
         logInfo s!"Successfully decoded double CBOR hex '{filename}'"
         return (toExpr p)
     | .error msg =>
-        throwError (decodingErrorWithSuggestion content `double_cbor_hex filename (some msg))
+        throwError (decodingErrorWithSuggestion content' `double_cbor_hex filename (some msg))
 
   /-- Parses a UPLC file and returns the resulting expression based on format -/
   parseUplcFile (stx : Syntax) : TermElabM Expr := do

--- a/PlutusCore/UPLC/ScriptEncoding/Basic.lean
+++ b/PlutusCore/UPLC/ScriptEncoding/Basic.lean
@@ -225,13 +225,12 @@ def importUplcImp : CommandElab := fun stx => do
     let content ← liftM $ do
       let path := System.FilePath.mk filename
       IO.FS.readFile path
-    let content' := String.trim content
-    match decodeProgramFromByteString content' with
+    match decodeProgramFromByteString content with
     | .some p =>
         logInfo s!"Successfully decoded '{filename}'"
         return (toExpr p)
     | .none =>
-        throwError (decodingErrorWithSuggestion content' `flat filename)
+        throwError (decodingErrorWithSuggestion content `flat filename)
 
   /-- Parses a flat hex-encoded UPLC file and returns the resulting expression -/
   parseFlatHexUplc (filename : String) : TermElabM Expr := do


### PR DESCRIPTION
## Description

Trims `#import_uplc` file contents, so starting and ending whitespaces are not taken into account at parsing hexencoded strings.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test updates

## Changes Made

Added a preprocessing step (`String.trim`) for all import functionality that expects hexencoded input.

## Testing

<!-- Describe the testing you have performed -->

### Test Coverage

- [ ] Added new tests for new functionality
- [ ] Updated existing tests
- [x] All tests pass locally
- [ ] For bug fixes: Added example to `Tests/Issues/` folder

## Documentation

- [ ] README updated (if applicable)
- [ ] Code comments added/updated
- [ ] Doc comments added for new optimization/rewritting rules

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes using `make check_all`
- [ ] For bug fixes: Original failing example added to `Tests/Issues/` folder with reference to issue number
