### PR TITLE
Fix conformance permissions

### DIFF
--- a/.github/workflows/ci-conformance.yaml
+++ b/.github/workflows/ci-conformance.yaml
@@ -39,9 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       checks: write
-      issues: write
 
     steps:
       - name: Acknowledge comment trigger


### PR DESCRIPTION
## Description

Minor tweaks to the conformance workflow's permission, it does not effect functionality, but upgrades developer experience:

- The "eyes" reaction pushed to the trigger comment needs the `pull-requests: write` permission.
- The `issues: write` permission is not needed.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Test updates

## Changes Made

- Upgraded the `pull-requests` permission to `write`.
- Removed the `issues: write` permission.

## Testing

Testing to be done by invoking the workflow action after merge.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes using `make check_all`

## Additional Notes

Only ci workflow is changed.
