### PR TITLE
Refactor binary script decoders to use ByteArray

### DIFF
--- a/PlutusCore/Cbor/Basic.lean
+++ b/PlutusCore/Cbor/Basic.lean
@@ -79,16 +79,13 @@ def encodeBytestring (s : ByteArray) : Option ByteArray :=
 /-- Encodes a natural number as a list of bytes in big-endian. -/
 -- Spec B.6. itos
 def itos (n : Nat) : ByteArray :=
-  let rec loop (acc : ByteArray) (n : Nat) :=
-    if h : n == 0
+  let rec loop (acc : List UInt8) (n : Nat) : List UInt8 :=
+    if h : n = 0
       then acc
-      else loop (acc.push (n % 256).toUInt8) (n / 256)
+      else loop ((n % 256).toUInt8 :: acc) (n / 256)
   termination_by n
-  decreasing_by
-    apply Nat.div_lt_self
-    · simp at h; omega
-    · omega
-  loop .empty n
+  decreasing_by omega
+  (loop [] n).toByteArray
 
 /-- Encodes an integer using zigzag encoding. -/
 -- Spec B.6. ε_Z

--- a/PlutusCore/Cbor/Basic.lean
+++ b/PlutusCore/Cbor/Basic.lean
@@ -20,84 +20,71 @@ namespace CborInternal
 /-- Returns the `i`th byte of `n` in little-endian ordering -/
 -- Spec B.4. 𝖻_𝑖(𝑛) = 𝗆𝗈𝖽(𝖽𝗂𝗏(𝑛, 256 ^ 𝑖), 256)
 @[simp]
-def b_ (i n : Nat) : Char := Char.ofNat ((n / (256 ^ i)) % 256)
+def b_ (i n : Nat) : UInt8 := ((n / (256 ^ i)) % 256).toUInt8
 
 /-- e_w: Returns the little-endian encoding of natural numbers in the prescribed width.
-    in CBOR only the forms e₁ e₂ e₄ and e₈ are used. -/
+    In CBOR only the forms e₁ e₂ e₄ and e₈ are used. -/
 -- Spec B.4. 𝖾_𝑘(𝑛) = [𝖻_(𝑘−1)(𝑛), … , 𝖻_0(𝑛)] if 𝑛 ≤ 256 ^ 𝑘 − 1.
-@[simp] def e₁ (n : Nat) : List Char := [b_ 0 n]
-@[simp] def e₂ (n : Nat) : List Char := [b_ 1 n, b_ 0 n]
-@[simp] def e₄ (n : Nat) : List Char := [b_ 3 n, b_ 2 n, b_ 1 n, b_ 0 n]
-@[simp] def e₈ (n : Nat) : List Char := [b_ 7 n, b_ 6 n, b_ 5 n, b_ 4 n, b_ 3 n, b_ 2 n, b_ 1 n, b_ 0 n]
+@[simp] def e₁ (n : Nat) : List UInt8 := [b_ 0 n]
+@[simp] def e₂ (n : Nat) : List UInt8 := [b_ 1 n, b_ 0 n]
+@[simp] def e₄ (n : Nat) : List UInt8 := [b_ 3 n, b_ 2 n, b_ 1 n, b_ 0 n]
+@[simp] def e₈ (n : Nat) : List UInt8 := [b_ 7 n, b_ 6 n, b_ 5 n, b_ 4 n, b_ 3 n, b_ 2 n, b_ 1 n, b_ 0 n]
 
 /-- ε_head: Encodes the major type (`m`) × Nat pair -/
 -- Spec B.4.
-def encodeHead (m n : Nat) : Option (List Char) :=
+def encodeHead (m n : Nat) : Option (List UInt8) :=
   if m ≤ 7 then
-         if n ≤                   23 then .some [Char.ofNat (32 * m + n)]
-    else if n ≤                  255 then .some (Char.ofNat (32 * m + 24) :: e₁ n)
-    else if n ≤                65535 then .some (Char.ofNat (32 * m + 25) :: e₂ n)
-    else if n ≤           4294967295 then .some (Char.ofNat (32 * m + 26) :: e₄ n)
-    else if n ≤ 18446744073709551615 then .some (Char.ofNat (32 * m + 27) :: e₈ n)
+         if n ≤                   23 then .some [(32 * m + n ).toUInt8]
+    else if n ≤                  255 then .some ((32 * m + 24).toUInt8 :: e₁ n)
+    else if n ≤                65535 then .some ((32 * m + 25).toUInt8 :: e₂ n)
+    else if n ≤           4294967295 then .some ((32 * m + 26).toUInt8 :: e₄ n)
+    else if n ≤ 18446744073709551615 then .some ((32 * m + 27).toUInt8 :: e₈ n)
     else .none
   else .none
 
-/-- Helper theorem used in  the termination proof for `splitToChunks` -/
-theorem String.data_length_of_nonEmpty_pos (s : String) (h : s ≠ "") : 0 < List.length s.data := by
-  obtain ⟨data⟩ := s
-  induction data
-  · contradiction
-  · simp
-
-/-- Helper theorem used in  the termination proof for `splitToChunks` -/
-theorem String.drop_decreases_data_length (s : String) (n : Nat) (hs : s ≠ "") (hn : 0 < n) : (List.drop n s.data).length < s.data.length := by
-    have hs0 : 0 < List.length s.data := String.data_length_of_nonEmpty_pos s hs
-    simp
-    omega
-
-def splitToChunksLoop (acc : List String) (s : String) : List String :=
-  if s = "" then List.reverse acc
-            else splitToChunksLoop (⟨List.take 64 s.data⟩ :: acc) ⟨List.drop 64 s.data⟩
-
-  termination_by (List.length s.data)
-  decreasing_by
-    apply String.drop_decreases_data_length <;> try assumption
-    omega
-
-/-- Splitting strings to chunks as it is implemented in Plutus and stated in the spec. -/
+/-- Splitting a byte list into 64-byte chunks. -/
 -- Spec B.5. "Canonical 64-byte decomposition"
-def splitToChunks := splitToChunksLoop []
+def splitToChunks : List UInt8 → List (List UInt8) :=
+  let rec loop acc s :=
+    if _ : s = [] then List.reverse acc
+                  else loop (List.take 64 s :: acc) (List.drop 64 s)
+    termination_by s.length
+    decreasing_by
+      have hne : s ≠ [] := by assumption
+      cases s with
+      | nil => exact absurd rfl hne
+      | cons _ _ =>
+        simp [List.length_drop]
+        omega
+  loop []
 
 /-- Some sequences are encoded without a specified length (indefinite length encoding). -/
 -- Spec B.4. Heads for indefinite-length items.
-def encodeIndef (m : Nat) : Char := Char.ofNat (32 * m + 31)
+def encodeIndef (m : Nat) : UInt8 := (32 * m + 31).toUInt8
 
-/-- Encodes a string chunk -/
+/-- Encodes a bytestring chunk. -/
 -- Spec B.5. ε_B*
-def encodeBytestringChunk (s : String) : Option (List Char) := do
-  let length := List.length s.data
+def encodeBytestringChunk (s : List UInt8) : Option (List UInt8) := do
+  let length := s.length
   if length ≤ 256 ^ 8
-    then .some ((←encodeHead 2 length) ++ s.data)
+    then .some ((←encodeHead 2 length) ++ s)
     else .none
 
-/-- Encodes a bytestring.
-    Note: it first splits the byte string to 64 byte chunks
-          as detailed in the specification. -/
+/-- Encodes a bytestring (internal, list-based).
+    First splits the byte list into 64-byte chunks as detailed in the specification. -/
 -- Spec B.5. ε_B*
-def encodeBytestring (s : String) : Option String :=
+def encodeBytestringL (s : List UInt8) : Option (List UInt8) :=
   match splitToChunks s with
-  | []      => String.mk <$> encodeHead 2 0  -- empty bytestring is a definite 0-length string (0x40)
-  | h :: [] => String.mk <$> encodeBytestringChunk h
-  | chunks  => do .some ⟨encodeIndef 2 :: (List.concat (←List.flatMapM encodeBytestringChunk chunks) '\xFF')⟩
+  | []      => encodeHead 2 0   -- empty bytestring is a definite 0-length string (0x40)
+  | h :: [] => encodeBytestringChunk h
+  | chunks  => do .some (encodeIndef 2 :: (List.concat (←List.flatMapM encodeBytestringChunk chunks) 0xFF))
 
-
-/-- Encodes a natural number as a list of characters in big-endian -/
+/-- Encodes a natural number as a list of bytes in big-endian. -/
 -- Spec B.6. itos
-def itos (n : Nat) : String :=
+def itos (n : Nat) : List UInt8 :=
   if n == 0
-    then ""
-    else itos (n / 256) ++ (n % 256 |> Char.ofNat |> String.singleton)
-
+    then []
+    else itos (n / 256) ++ [(n % 256).toUInt8]
   decreasing_by
     apply Nat.div_lt_self
     · have h : ¬(n == 0) = true := by assumption
@@ -105,48 +92,47 @@ def itos (n : Nat) : String :=
       omega
     · omega
 
-/-- Encodes an integer using zigzag encoding -/
+/-- Encodes an integer using zigzag encoding (internal, list-based). -/
 -- Spec B.6. ε_Z
-def encodeInt (n : Integer) : Option String :=
-       if (                    0 ≤ n) && (n ≤  18446744073709551615) then String.mk <$> encodeHead 0 (Int.toNat n)
-  else if ( 18446744073709551616 ≤ n)                                then do (String.mk (←encodeHead 6 2)) ++ (←encodeBytestring (n |> Int.toNat |> itos))
-  else if (-18446744073709551616 ≤ n) && (n ≤                    -1) then String.mk <$> encodeHead 1 ((-n - 1) |> Int.toNat)
-  else if                                (n ≤ -18446744073709551617) then do (String.mk (←encodeHead 6 3)) ++ (←encodeBytestring (-n - 1 |> Int.toNat |> itos))
+def encodeIntL (n : Integer) : Option (List UInt8) :=
+       if (                    0 ≤ n) && (n ≤  18446744073709551615) then encodeHead 0 (Int.toNat n)
+  else if ( 18446744073709551616 ≤ n)                                then do return (←encodeHead 6 2) ++ (←encodeBytestringL (itos (Int.toNat n)))
+  else if (-18446744073709551616 ≤ n) && (n ≤                    -1) then encodeHead 1 ((-n - 1) |> Int.toNat)
+  else if                                (n ≤ -18446744073709551617) then do return (←encodeHead 6 3) ++ (←encodeBytestringL (itos (Int.toNat (-n - 1))))
   else .none
 
-/-- Encodes a ctag. -/
+/-- Encodes a ctag (internal, list-based). -/
 -- Spec B.7. ε_ctag
-def encodeCtag (i : Integer) : Option String :=
-  String.mk <$>
-         if (0 ≤ i) && (i ≤   6) then encodeHead 6 ( 121 + i       |> Int.toNat)
-    else if (7 ≤ i) && (i ≤ 127) then encodeHead 6 (1280 + (i - 7) |> Int.toNat)
-    else do (←encodeHead 6 102) ++ (←encodeHead 4 2) ++ ((←encodeInt i).data)
+def encodeCtagL (i : Integer) : Option (List UInt8) :=
+       if (0 ≤ i) && (i ≤   6) then encodeHead 6 ( 121 + i       |> Int.toNat)
+  else if (7 ≤ i) && (i ≤ 127) then encodeHead 6 (1280 + (i - 7) |> Int.toNat)
+  else do return (←encodeHead 6 102) ++ (←encodeHead 4 2) ++ (←encodeIntL i)
 
-/-- Encode data (builtinData). -/
+/-- Encode data (builtinData) (internal, list-based). -/
 -- Spec B.7. Encoding and  decoding Data. ε_data
-def encodeData : Data → Option String
+def encodeDataL : Data → Option (List UInt8)
   | .Constr idx fields =>
       if fields.isEmpty then do
         -- empty field list is a DEFINITE empty array (0x80), matching the serialiseData builtin
-        (←encodeCtag idx) ++ (String.mk (←encodeHead 4 0))
+        (←encodeCtagL idx) ++ (←encodeHead 4 0)
       else do
-        (←encodeCtag idx)
-        ++ (encodeIndef 4 |> String.singleton)
-        ++ (←List.foldlM (λ s a => do .some (s ++ (←encodeData a))) "" fields)
-        ++ "\xFF"
+        (←encodeCtagL idx)
+        ++ [encodeIndef 4]
+        ++ (←List.foldlM (λ s a => do .some (s ++ (←encodeDataL a))) [] fields)
+        ++ [UInt8.ofNat 0xFF]
   | .Map mxs => do
-      ((←encodeHead 5 (List.length mxs)) |> String.mk)
-      ++ (←List.foldlM (λ s p => do .some (s ++ (←encodeData p.fst) ++ (←encodeData p.snd))) "" mxs)
+      (←encodeHead 5 mxs.length)
+      ++ (←List.foldlM (λ s p => do .some (s ++ (←encodeDataL p.fst) ++ (←encodeDataL p.snd))) [] mxs)
   | .List xs =>
       if xs.isEmpty then
         -- empty list is a DEFINITE empty array (0x80), matching the serialiseData builtin
-        String.mk <$> encodeHead 4 0
+        encodeHead 4 0
       else do
-        (encodeIndef 4 |> String.singleton)
-        ++ (←List.foldlM (λ s a => do .some (s ++ (←encodeData a))) "" xs)
-        ++ "\xFF"
-  | .I i => encodeInt i
-  | .B bs => encodeBytestring bs.data
+        [encodeIndef 4]
+        ++ (←List.foldlM (λ s a => do .some (s ++ (←encodeDataL a))) [] xs)
+        ++ [UInt8.ofNat 0xFF]
+  | .I i  => encodeIntL i
+  | .B bs => encodeBytestringL (Char.toUInt8 <$> bs.data.data)
 
   decreasing_by
     · have : sizeOf a     < sizeOf fields := by apply List.sizeOf_lt_of_mem; assumption
@@ -159,6 +145,31 @@ def encodeData : Data → Option String
       simp; omega
     · have : sizeOf a     < sizeOf xs     := by apply List.sizeOf_lt_of_mem; assumption
       simp; omega
+
+/-- Converts a UPLC `ByteString` (which wraps a `String` of codepoint-as-byte
+    chars) to its `ByteArray` representation. -/
+@[inline] def byteStringToByteArray (bs : ByteString) : ByteArray :=
+  (Char.toUInt8 <$> bs.data.data).toByteArray
+
+/-- Encodes a bytestring. -/
+-- Spec B.5. ε_B*
+@[inline] def encodeBytestring (b : ByteArray) : Option ByteArray :=
+  (encodeBytestringL b.toList).map List.toByteArray
+
+/-- Encodes an integer using zigzag encoding. -/
+-- Spec B.6. ε_Z
+@[inline] def encodeInt (n : Integer) : Option ByteArray :=
+  (encodeIntL n).map List.toByteArray
+
+/-- Encodes a ctag. -/
+-- Spec B.7. ε_ctag
+@[inline] def encodeCtag (i : Integer) : Option ByteArray :=
+  (encodeCtagL i).map List.toByteArray
+
+/-- Encode data (builtinData). -/
+-- Spec B.7. Encoding and decoding Data. ε_data
+@[inline] def encodeData (d : Data) : Option ByteArray :=
+  (encodeDataL d).map List.toByteArray
 
 -- ==============
 -- =  Decoding  =

--- a/PlutusCore/Cbor/Basic.lean
+++ b/PlutusCore/Cbor/Basic.lean
@@ -366,7 +366,7 @@ theorem d₈_consumes (d : DecodeState) :
 private theorem decodeHead_di_branch_consumes {d d' : DecodeState} {n' : UInt8} {dv k δ : Nat}
   {dx : DecodeState → Option (DecodeState × Nat)}
   (hdx_cons : ∀ d₀ k₀, dx d.advance = some (d₀, k₀) → d₀.input = (d.advance).input ∧ d₀.pos = (d.advance).pos + δ ∧ d₀.pos ≤ (d.advance).input.size)
-  (h : (fun (p : DecodeState × Nat) => (p.1, n'.toNat / 32, p.2)) <$> dx d.advance = some (d', dv, k)) :
+  (h : (λ (p : DecodeState × Nat) => (p.1, n'.toNat / 32, p.2)) <$> dx d.advance = some (d', dv, k)) :
   d'.input = d.input ∧ d'.pos > d.pos ∧ d'.pos ≤ d.input.size := by
     rcases hdx : dx d.advance with _ | ⟨d_st, n_val⟩
     · rw [hdx] at h; simp at h
@@ -578,8 +578,8 @@ theorem decodeBytestringL_consumes (d : DecodeState) :
 /-- Decodes a bytestring from the input `b`. -/
 -- Spec B.5. D_B*
 def decodeBytestring (b : ByteArray) : Option (ByteArray × ByteArray) :=
-  (decodeBytestringL { input := b, pos := 0 }).map fun (d', t) =>
-    (d'.input.extract d'.pos d'.input.size, t)
+  (decodeBytestringL { input := b, pos := 0 }).map (λ (d', t) =>
+    (d'.input.extract d'.pos d'.input.size, t))
 
 /-- Decodes a "large" block, which can have a length larger than 64 bytes. -/
 def decodeLargeBlock (d : DecodeState) : Option (DecodeState × ByteArray) := do
@@ -690,12 +690,12 @@ def decodeLargeBytestringL (d : DecodeState) : Option (DecodeState × ByteArray)
 
 /-- Decodes a "large" bytestring from a `ByteArray`. -/
 def decodeLargeBytestring (b : ByteArray) : Option (ByteArray × ByteArray) :=
-  (decodeLargeBytestringL { input := b, pos := 0 }).map fun (d', t) =>
-    (d'.input.extract d'.pos d'.input.size, t)
+  (decodeLargeBytestringL { input := b, pos := 0 }).map (λ (d', t) =>
+    (d'.input.extract d'.pos d'.input.size, t))
 
 /-- Reconstructs a natural number from its big endian representation. -/
 -- Spec B.6. stoi
-def stoi (b : ByteArray) : Nat := b.foldl (fun acc x => acc * 256 + x.toNat) 0
+def stoi (b : ByteArray) : Nat := b.foldl (λ acc x => acc * 256 + x.toNat) 0
 
 /-- Decodes an integer value from a `DecodeState` (internal). -/
 def decodeIntL (d : DecodeState) : Option (DecodeState × Integer) :=
@@ -755,8 +755,8 @@ theorem decodeIntL_consumes (d : DecodeState) :
 /-- Decodes an integer value from a `ByteArray`. -/
 --  Spec B.6. D_Z
 def decodeInt (b : ByteArray) : Option (ByteArray × Integer) :=
-  (decodeIntL { input := b, pos := 0 }).map fun (d', i) =>
-    (d'.input.extract d'.pos d'.input.size, i)
+  (decodeIntL { input := b, pos := 0 }).map (λ (d', i) =>
+    (d'.input.extract d'.pos d'.input.size, i))
 
 /-- Decodes a ctag from a `DecodeState`. -/
 -- Spec B.7. D_ctag
@@ -968,8 +968,8 @@ end
 -- Data.hs accepts: indefinite maps (decodePairListIndef) and the indefinite tag-102 constructor
 -- wrapper (decodeIndefConstr). Decode-only, the encoder is unchanged.
 def decodeData (b : ByteArray) : Option (ByteArray × Data) :=
-  (decodeDataLoop { input := b, pos := 0 }).map fun (d', x) =>
-    (d'.input.extract d'.pos d'.input.size, x)
+  (decodeDataLoop { input := b, pos := 0 }).map (λ (d', x) =>
+    (d'.input.extract d'.pos d'.input.size, x))
 
 end CborInternal
 

--- a/PlutusCore/Cbor/Basic.lean
+++ b/PlutusCore/Cbor/Basic.lean
@@ -164,36 +164,47 @@ def encodeData : Data → Option String
 -- =  Decoding  =
 -- ==============
 
+/-- Wrap a list of bytes into the UPLC `ByteString` domain value.
+    `ByteString` is intentionally a wrapper around `String` (Haskell-compat),
+    so a list of bytes is encoded by mapping each byte to the corresponding
+    Char codepoint 0-255. -/
+@[inline] def bytesToByteString (bs : List UInt8) : ByteString :=
+  ⟨String.mk (Char.ofUInt8 <$> bs)⟩
+
+/-- Wrap a `ByteArray` into the UPLC `ByteString` domain value. -/
+@[inline] def byteArrayToByteString (b : ByteArray) : ByteString :=
+  bytesToByteString b.toList
+
 /-- Helper function that is used in reconstructing natural numbers from their big endian representation -/
-def d_ (i : Nat) (c : Char) := (Char.toNat c) * (256 ^ i)
+def d_ (i : Nat) (c : UInt8) := c.toNat * (256 ^ i)
 
 -- Spec B.4. The `d_k` function is a general function to reconstruct a `k` byte natural number
 -- from its big endian representation. In the spec only the forms with k = 1, 2, 4 and 8 are used.
 /-- Decodes a one byte integer. -/
-def d₁ : List Char → Option (List Char × Nat)
-  | b :: t => .some (t, Char.toNat b)
+def d₁ : List UInt8 → Option (List UInt8 × Nat)
+  | b :: t => .some (t, b.toNat)
   | []     => .none
 
 /-- Decodes a two byte integer. -/
-def d₂ : List Char → Option (List Char × Nat)
+def d₂ : List UInt8 → Option (List UInt8 × Nat)
   | b₁ :: b₀ :: t => .some (t, d_ 1 b₁ + d_ 0 b₀)
   | _             => .none
 
 /-- Decodes a four byte integer. -/
-def d₄ : List Char → Option (List Char × Nat)
+def d₄ : List UInt8 → Option (List UInt8 × Nat)
   | b₃ :: b₂ :: b₁ :: b₀ :: t => .some (t, d_ 3 b₃ + d_ 2 b₂ + d_ 1 b₁ + d_ 0 b₀)
   | _                         => .none
 
 /-- Decodes an eight byte integer. -/
-def d₈ : List Char → Option (List Char × Nat)
+def d₈ : List UInt8 → Option (List UInt8 × Nat)
   | b₇ :: b₆ :: b₅ :: b₄ :: b₃ :: b₂ :: b₁ :: b₀ :: t => .some (t, d_ 7 b₇ + d_ 6 b₆ + d_ 5 b₅ + d_ 4 b₄ + d_ 3 b₃ + d_ 2 b₂ + d_ 1 b₁ + d_ 0 b₀)
   | _                                                 => .none
 
 /-- Decodes a "head" structure that describes how the next bytes should be interpreted. -/
 -- Spec B.4. D_head
-def decodeHead : List Char → Option ((List Char) × Nat × Nat)
+def decodeHead : List UInt8 → Option ((List UInt8) × Nat × Nat)
   | n' :: s =>
-      let n := Char.toNat n'
+      let n := n'.toNat
       let d := n / 32
       match n % 32 with
       | 24 => (λ (s', k) => (s', d, k)) <$> d₁ s
@@ -206,15 +217,15 @@ def decodeHead : List Char → Option ((List Char) × Nat × Nat)
 
 /-- Decodes a "head" structure with indefinite length that describes how the next bytes should be interpreted. -/
 -- Spec B.4. D_indef
-def decodeIndef : List Char → Option (List Char × Nat)
+def decodeIndef : List UInt8 → Option (List UInt8 × Nat)
   | n' :: s =>
-      let n := Char.toNat n'
+      let n := n'.toNat
       if n % 32 = 31
         then .some (s, n / 32)
         else .none
   | [] => .none
 
-def decodeBytesLoop (acc : List Char) : Nat → List Char → Option (List Char × List Char)
+def decodeBytesLoop (acc : List UInt8) : Nat → List UInt8 → Option (List UInt8 × List UInt8)
   | .zero  , s       => .some (s, (List.reverse acc))
   | .succ _, []      => .none
   | .succ p, b :: s' => decodeBytesLoop (b :: acc) p s'
@@ -225,7 +236,7 @@ def decodeBytes := decodeBytesLoop []
 
 /-- Decodes a definite length "block" (bytestring chunk). -/
 -- Spec B.5. D_block
-def decodeBlock (s : List Char) : Option (List Char × List Char) := do
+def decodeBlock (s : List UInt8) : Option (List UInt8 × List UInt8) := do
   let (s', m, n) ← decodeHead s
   if m = 2 ∧ n ≤ 64
     then decodeBytes n s'
@@ -236,7 +247,7 @@ def decodeBlock (s : List Char) : Option (List Char × List Char) := do
 -- ==========================
 
 /-- Helper theorem: decodeHead always consumes at least one byte on success -/
-theorem decodeHead_consumes (s : List Char) :
+theorem decodeHead_consumes (s : List UInt8) :
   ∀ s' d k, decodeHead s = some (s', d, k) → s'.length < s.length := by
   intro s' d k h
   unfold decodeHead at h
@@ -331,7 +342,7 @@ theorem decodeHead_consumes (s : List Char) :
       · simp at h
 
 /-- Helper theorem: decodeBytesLoop consumes exactly n bytes regardless of accumulator -/
-theorem decodeBytesLoop_consumes : ∀ (acc : List Char) (n : Nat) (s : List Char) (s' t : List Char),
+theorem decodeBytesLoop_consumes : ∀ (acc : List UInt8) (n : Nat) (s : List UInt8) (s' t : List UInt8),
   decodeBytesLoop acc n s = some (s', t) → s'.length + n = s.length := by
   intro acc n s s' t h
   revert acc s s' t
@@ -355,14 +366,14 @@ theorem decodeBytesLoop_consumes : ∀ (acc : List Char) (n : Nat) (s : List Cha
         _ = s''.length + 1 := by rw [ih_result]
 
 /-- Helper theorem: decodeBytes consumes exactly n bytes on success -/
-theorem decodeBytes_consumes (n : Nat) (s : List Char) :
+theorem decodeBytes_consumes (n : Nat) (s : List UInt8) :
   ∀ s' t, decodeBytes n s = some (s', t) → s'.length + n = s.length := by
   intro s' t h
   unfold decodeBytes at h
   exact decodeBytesLoop_consumes [] n s s' t h
 
 /-- Helper theorem: decodeBlock consumes at least one byte on success -/
-theorem decodeBlock_consumes (s : List Char) :
+theorem decodeBlock_consumes (s : List UInt8) :
   ∀ s' t, decodeBlock s = some (s', t) → s'.length < s.length := by
   intro s' t h
   unfold decodeBlock at h
@@ -375,7 +386,7 @@ theorem decodeBlock_consumes (s : List Char) :
   · simp at h
 
 /-- Helper theorem: decodeIndef consumes exactly one byte on success -/
-theorem decodeIndef_consumes (s : List Char) :
+theorem decodeIndef_consumes (s : List UInt8) :
   ∀ s' n, decodeIndef s = some (s', n) → s'.length + 1 = s.length := by
   intro s' n h
   unfold decodeIndef at h
@@ -394,8 +405,8 @@ theorem decodeIndef_consumes (s : List Char) :
 
 set_option linter.unusedVariables false
 
-def decodeBlocksLoop (acc : List Char) : (s : List Char) → Option (List Char × List Char)
-  | '\xFF' :: s' => .some (s', List.reverse acc)
+def decodeBlocksLoop (acc : List UInt8) : (s : List UInt8) → Option (List UInt8 × List UInt8)
+  | 0xFF :: s' => .some (s', List.reverse acc)
   | s => match h : decodeBlock s with
       | some (s', t) => decodeBlocksLoop ((List.reverse t) ++ acc) s'
       | none => none
@@ -413,7 +424,7 @@ def decodeBlocks := decodeBlocksLoop []
 
 /-- Helper theorem: decodeBlocksLoop consumes bytes when recursing. -/
 theorem decodeBlocksLoop_consumes :
-  ∀ (n : Nat) (acc s s' : List Char) (t : List Char),
+  ∀ (n : Nat) (acc s s' : List UInt8) (t : List UInt8),
     s.length ≤ n → decodeBlocksLoop acc s = some (s', t) → s'.length < s.length := by
   intro n
   induction n with
@@ -433,7 +444,7 @@ theorem decodeBlocksLoop_consumes :
     | c :: rest =>
       unfold decodeBlocksLoop at h
       split at h
-      · -- Case: c = '\xFF'
+      · -- Case: c = 0xFF
         rename_i s'' heq
         simp at h
         obtain ⟨h1, h2⟩ := h
@@ -441,7 +452,7 @@ theorem decodeBlocksLoop_consumes :
         injection heq with heq_c heq_rest
         subst heq_rest
         simp
-      · -- Case: c ≠ '\xFF', must use decodeBlock
+      · -- Case: c ≠ 0xFF, must use decodeBlock
         split at h
         · -- decodeBlock succeeds and recurses
           rename_i s'' t' hdb
@@ -461,30 +472,28 @@ theorem decodeBlocks_consumes : ∀ s s' t, decodeBlocks s = some (s', t) → s'
   unfold decodeBlocks at h
   exact decodeBlocksLoop_consumes s.length [] s s' t (Nat.le_refl _) h
 
-/-- Decodes a bytestring from the input `s`. -/
--- Spec B.5. D_B*
-def decodeBytestring (s : String) : Option (String × String) :=
-  match decodeBlock s.data with
-  | .some (s', t) => .some (⟨s'⟩, ⟨t⟩)
+/-- Decodes a bytestring from the input list of bytes (internal, list-based). -/
+def decodeBytestringL (s : List UInt8) : Option (List UInt8 × List UInt8) :=
+  match decodeBlock s with
+  | .some (s', t) => .some (s', t)
   | .none         => do
-      let (s', n) ← decodeIndef s.data
+      let (s', n) ← decodeIndef s
       if n = 2
-        then Prod.map String.mk String.mk <$> decodeBlocks s'
+        then decodeBlocks s'
         else .none
 
-/-- Helper theorem: decodeBytestring consumes at least one byte on success -/
-theorem decodeBytestring_consumes (s : String) :
-  ∀ s' t, decodeBytestring s = some (s', t) → s'.data.length < s.data.length := by
+/-- Helper theorem: decodeBytestringL consumes at least one byte on success -/
+theorem decodeBytestringL_consumes (s : List UInt8) :
+  ∀ s' t, decodeBytestringL s = some (s', t) → s'.length < s.length := by
   intro s' t h
-  unfold decodeBytestring at h
+  unfold decodeBytestringL at h
   split at h
   · -- Case: decodeBlock succeeds
     rename_i s'' t' hdb
     simp at h
     obtain ⟨h1, h2⟩ := h
     rw [← h1]
-    simp
-    exact decodeBlock_consumes s.data s'' t' hdb
+    exact decodeBlock_consumes s s'' t' hdb
   · -- Case: decodeBlock fails, try decodeIndef + decodeBlocks
     simp only [Option.bind_eq_bind, Option.bind_eq_some_iff] at h
     obtain ⟨⟨s'', n⟩, hdi, h_rest⟩ := h
@@ -492,24 +501,29 @@ theorem decodeBytestring_consumes (s : String) :
     · cases h_blocks : decodeBlocks s'' with
       | none => simp [h_blocks] at h_rest
       | some res =>
-        simp [Prod.map, h_blocks] at h_rest
+        rcases res with ⟨ra, rb⟩
+        simp [h_blocks] at h_rest
         obtain ⟨h_eq1, h_eq2⟩ := h_rest
         rw [← h_eq1]
-        simp
-        have h1 := decodeIndef_consumes s.data s'' n hdi
-        have h2 := decodeBlocks_consumes s'' res.1 res.2 h_blocks
+        have h1 := decodeIndef_consumes s s'' n hdi
+        have h2 := decodeBlocks_consumes s'' ra rb h_blocks
         omega
     · simp at h_rest
 
+/-- Decodes a bytestring from the input `b`. -/
+-- Spec B.5. D_B*
+def decodeBytestring (b : ByteArray) : Option (ByteArray × ByteArray) :=
+  (decodeBytestringL b.toList).map (fun (rem, bs) => (rem.toByteArray, bs.toByteArray))
+
 /-- Decodes a "large" block, which can have a length larger than 64 bytes. -/
-def decodeLargeBlock (s : List Char) : Option (List Char × List Char) := do
+def decodeLargeBlock (s : List UInt8) : Option (List UInt8 × List UInt8) := do
   let (s', m, n) ← decodeHead s
   if m = 2
     then decodeBytes n s'
     else .none
 
 /-- Helper theorem: decodeLargeBlock consumes at least one byte on success -/
-theorem decodeLargeBlock_consumes (s : List Char) :
+theorem decodeLargeBlock_consumes (s : List UInt8) :
   ∀ s' t, decodeLargeBlock s = some (s', t) → s'.length < s.length := by
   intro s' t h
   unfold decodeLargeBlock at h
@@ -521,10 +535,9 @@ theorem decodeLargeBlock_consumes (s : List Char) :
     omega
   · simp at h
 
-set_option linter.unusedVariables false
-
-def decodeLargeBlocksLoop (acc : List Char) : List Char → Option (List Char × List Char)
-  | '\xFF' :: s' => .some (s', List.reverse acc)
+set_option linter.unusedVariables false in
+def decodeLargeBlocksLoop (acc : List UInt8) : List UInt8 → Option (List UInt8 × List UInt8)
+  | 0xFF :: s' => .some (s', List.reverse acc)
   | s            => match h : decodeLargeBlock s with
       | some (s', t) => decodeLargeBlocksLoop ((List.reverse t) ++ acc) s'
       | none => none
@@ -534,91 +547,91 @@ decreasing_by
   have := decodeLargeBlock_consumes s s' t h
   omega
 
-set_option linter.unusedVariables true
-
 /-- Decodes a sequence of "large" blocks. -/
 def decodeLargeBlocks := decodeLargeBlocksLoop []
 
-/-- Decodes a "large" bytestring, which can have blocks larger than 64 bytes. -/
-def decodeLargeBytestring (s : String) : Option (String × String) :=
-  match decodeLargeBlock s.data with
-  | .some (s', t) => .some (⟨s'⟩, ⟨t⟩)
+/-- Decodes a "large" bytestring from a list of bytes (internal, list-based). -/
+def decodeLargeBytestringL (s : List UInt8) : Option (List UInt8 × List UInt8) :=
+  match decodeLargeBlock s with
+  | .some (s', t) => .some (s', t)
   | .none         => do
-      let (s', n) ← decodeIndef s.data
+      let (s', n) ← decodeIndef s
       if n = 2
-        then Prod.map String.mk String.mk <$> decodeLargeBlocks s'
+        then decodeLargeBlocks s'
         else .none
+
+/-- Decodes a "large" bytestring from a `ByteArray`. -/
+def decodeLargeBytestring (b : ByteArray) : Option (ByteArray × ByteArray) :=
+  (decodeLargeBytestringL b.toList).map (fun (rem, bs) => (rem.toByteArray, bs.toByteArray))
 
 /-- Reconstructs a natural number from its big endian representation. -/
 -- Spec B.6. stoi
-def stoi (s : String) : Nat :=
-  let rec go : List Char → Nat
+def stoi (bs : List UInt8) : Nat :=
+  let rec go : List UInt8 → Nat
     | []      => 0
-    | n :: l' => 256 * go l' + (Char.toNat n)
-  go (List.reverse s.data)
+    | n :: l' => 256 * go l' + n.toNat
+  go (List.reverse bs)
 
-/- Decodes an integer value from input `s`. -/
---  Spec B.6. D_Z
-def decodeInt (s : String) : Option (String × Integer) :=
-  match decodeHead s.data with
-  | .some (s', 0, n) => .some (⟨s'⟩,  (Int.ofNat n)    )
-  | .some (s', 1, n) => .some (⟨s'⟩, -(Int.ofNat n) - 1)
-  | .some (s', 6, 2) => (λ (s'', b) => (s'',              stoi b      )) <$> decodeBytestring ⟨s'⟩
-  | .some (s', 6, 3) => (λ (s'', b) => (s'', -(Int.ofNat (stoi b)) - 1)) <$> decodeBytestring ⟨s'⟩
+/- Decodes an integer value from a list of bytes (internal, list-based). -/
+def decodeIntL (s : List UInt8) : Option (List UInt8 × Integer) :=
+  match decodeHead s with
+  | .some (s', 0, n) => .some (s',  (Int.ofNat n)    )
+  | .some (s', 1, n) => .some (s', -(Int.ofNat n) - 1)
+  | .some (s', 6, 2) => (λ (s'', b) => (s'',              stoi b      )) <$> decodeBytestringL s'
+  | .some (s', 6, 3) => (λ (s'', b) => (s'', -(Int.ofNat (stoi b)) - 1)) <$> decodeBytestringL s'
   | _                => .none
 
-/-- Helper theorem: decodeInt consumes at least one byte on success -/
-theorem decodeInt_consumes (s : String) :
-  ∀ s' i, decodeInt s = some (s', i) → s'.data.length < s.data.length := by
+/-- Helper theorem: decodeIntL consumes at least one byte on success -/
+theorem decodeIntL_consumes (s : List UInt8) :
+  ∀ s' i, decodeIntL s = some (s', i) → s'.length < s.length := by
   intro s' i h
-  unfold decodeInt at h
+  unfold decodeIntL at h
   split at h
-  · -- Case: decodeHead s.data = some (k, 0, n)
+  · -- Case: decodeHead s = some (k, 0, n)
     rename_i k n hdh
     simp at h
     obtain ⟨h1, h2⟩ := h
     rw [← h1]
-    simp
-    exact decodeHead_consumes s.data k 0 n hdh
-  · -- Case: decodeHead s.data = some (k, 1, n)
+    exact decodeHead_consumes s k 0 n hdh
+  · -- Case: decodeHead s = some (k, 1, n)
     rename_i k n hdh
     simp at h
     obtain ⟨h1, h2⟩ := h
     rw [← h1]
-    simp
-    exact decodeHead_consumes s.data k 1 n hdh
-  · -- Case: decodeHead s.data = some (k, 6, 2), calls decodeBytestring
+    exact decodeHead_consumes s k 1 n hdh
+  · -- Case: decodeHead s = some (k, 6, 2), calls decodeBytestringL
     rename_i k hdh
-    cases h_db : decodeBytestring ⟨k⟩ with
+    cases h_db : decodeBytestringL k with
     | none => simp [h_db] at h
     | some res =>
       simp [h_db] at h
       obtain ⟨h1, h2⟩ := h
-      have h_head := decodeHead_consumes s.data k 6 2 hdh
-      have h_bs := decodeBytestring_consumes ⟨k⟩ res.1 res.2 h_db
-      simp at h_bs
+      have h_head := decodeHead_consumes s k 6 2 hdh
+      have h_bs := decodeBytestringL_consumes k res.1 res.2 h_db
       rw [← h1]
-      simp
       omega
-  · -- Case: decodeHead s.data = some (k, 6, 3), calls decodeBytestring
+  · -- Case: decodeHead s = some (k, 6, 3), calls decodeBytestringL
     rename_i k hdh
-    cases h_db : decodeBytestring ⟨k⟩ with
+    cases h_db : decodeBytestringL k with
     | none => simp [h_db] at h
     | some res =>
       simp [h_db] at h
       obtain ⟨h1, h2⟩ := h
-      have h_head := decodeHead_consumes s.data k 6 3 hdh
-      have h_bs := decodeBytestring_consumes ⟨k⟩ res.1 res.2 h_db
-      simp at h_bs
+      have h_head := decodeHead_consumes s k 6 3 hdh
+      have h_bs := decodeBytestringL_consumes k res.1 res.2 h_db
       rw [← h1]
-      simp
       omega
   · -- Case: decodeHead fails or other cases
     simp at h
 
+/- Decodes an integer value from a `ByteArray`. -/
+--  Spec B.6. D_Z
+def decodeInt (b : ByteArray) : Option (ByteArray × Integer) :=
+  (decodeIntL b.toList).map (fun (rem, i) => (rem.toByteArray, i))
+
 /- Decodes a ctag from input `s`. -/
 -- Spec B.7. D_ctag
-def decodeCtag (s : List Char) : Option (List Char × Integer) :=
+def decodeCtag (s : List UInt8) : Option (List UInt8 × Integer) :=
   match decodeHead s with
   | .some (s', 6, 102) => do
       -- The definite 2-element wrapper (0x82) is accepted here. The indefinite form
@@ -637,13 +650,13 @@ def decodeCtag (s : List Char) : Option (List Char × Integer) :=
   | _ => .none
 
 /- Tries to decode a value from `s` using `f`. If fails it tries `g` with the same input. Fails if both fails. -/
-def decodeAlternative {α β : Type} (f : List Char → Option (List Char × α)) (g : List Char → Option (List Char × β)) (s : List Char) : Option (List Char × (α ⊕ β)) :=
+def decodeAlternative {α β : Type} (f : List UInt8 → Option (List UInt8 × α)) (g : List UInt8 → Option (List UInt8 × β)) (s : List UInt8) : Option (List UInt8 × (α ⊕ β)) :=
   match f s with
   | .some (s', a) => .some (s', .inl a)
   | .none         => (λ (s', b) => (s', .inr b)) <$> g s
 
 /-- Helper theorem: decodeAlternative consumes at least one byte on success -/
-theorem decodeAlternative_indef_head_consumes (s : List Char) :
+theorem decodeAlternative_indef_head_consumes (s : List UInt8) :
   ∀ s' r, decodeAlternative decodeIndef decodeHead s = some (s', r) → s'.length < s.length := by
   intro s' r h
   unfold decodeAlternative at h
@@ -661,7 +674,7 @@ theorem decodeAlternative_indef_head_consumes (s : List Char) :
     exact decodeHead_consumes s b hdh hb heq_head
 
 /-- Helper theorem: decodeCtag consumes at least one byte on success -/
-theorem decodeCtag_consumes (s : List Char) :
+theorem decodeCtag_consumes (s : List UInt8) :
   ∀ s' i, decodeCtag s = some (s', i) → s'.length < s.length := by
   intro s' i h
   unfold decodeCtag at h
@@ -711,23 +724,23 @@ theorem decodeCtag_consumes (s : List Char) :
 -- requires lemmas about byte consumption that create circular dependencies.
 mutual
   -- Main decoder loop for Data values
-  partial def decodeDataLoop (s : List Char) : Option (List Char × Data) :=
+  partial def decodeDataLoop (s : List UInt8) : Option (List UInt8 × Data) :=
     match decodeAlternative decodeIndef decodeHead s with
-    | .some (_ , .inl 2     ) => Prod.map String.data (.B ∘ ByteString.mk) <$> decodeBytestring ⟨s⟩
-    | .some (s', .inl 4     ) => Prod.map id          .List                <$> decodeListIndef s'
-    | .some (s', .inl 5     ) => Prod.map id          .Map                 <$> decodePairListIndef s'
+    | .some (_ , .inl 2     ) => Prod.map id (.B ∘ bytesToByteString) <$> decodeBytestringL s
+    | .some (s', .inl 4     ) => Prod.map id .List                    <$> decodeListIndef s'
+    | .some (s', .inl 5     ) => Prod.map id .Map                     <$> decodePairListIndef s'
     | .some (_ , .inr (0, _))
     | .some (_ , .inr (1, _))
     | .some (_ , .inr (6, 2))
-    | .some (_ , .inr (6, 3)) => Prod.map String.data .I                   <$> decodeInt ⟨s⟩
-    | .some (_ , .inr (2, _)) => Prod.map String.data (.B ∘ ByteString.mk) <$> decodeBytestring ⟨s⟩
-    | .some (s', .inr (4, n)) => Prod.map id          .List                <$> decodeList n s'
-    | .some (s', .inr (5, n)) => Prod.map id          .Map                 <$> decodePairList n s'
-    | .some (_ , .inr (6, _)) =>                                               decodeConstr s
+    | .some (_ , .inr (6, 3)) => Prod.map id .I                       <$> decodeIntL s
+    | .some (_ , .inr (2, _)) => Prod.map id (.B ∘ bytesToByteString) <$> decodeBytestringL s
+    | .some (s', .inr (4, n)) => Prod.map id .List                    <$> decodeList n s'
+    | .some (s', .inr (5, n)) => Prod.map id .Map                     <$> decodePairList n s'
+    | .some (_ , .inr (6, _)) =>                                          decodeConstr s
     | _ => .none
 
   -- Decode a fixed-length list of Data values
-  partial def decodeList : Nat → List Char → Option (List Char × List Data)
+  partial def decodeList : Nat → List UInt8 → Option (List UInt8 × List Data)
     | .zero  , s => .some (s, [])
     | .succ p, s => match decodeDataLoop s with
         | some (s', d) => match decodeList p s' with
@@ -736,8 +749,8 @@ mutual
         | none => none
 
   -- Decode an indefinite-length list of Data values
-  partial def decodeListIndef : List Char → Option (List Char × List Data)
-    | '\xFF' :: s' => .some (s', [])
+  partial def decodeListIndef : List UInt8 → Option (List UInt8 × List Data)
+    | 0xFF :: s' => .some (s', [])
     | s            => match decodeDataLoop s with
         | some (s', d) => match decodeListIndef s' with
             | some (s'', l) => some (s'', d :: l)
@@ -745,7 +758,7 @@ mutual
         | none => none
 
   -- Decode a fixed-length list of Data pairs (for Map)
-  partial def decodePairList : Nat → List Char → Option (List Char × List (Data × Data))
+  partial def decodePairList : Nat → List UInt8 → Option (List UInt8 × List (Data × Data))
     | .zero  , s => .some (s, [])
     | .succ p, s => match decodeDataLoop s with
         | some (s', k) => match decodeDataLoop s' with
@@ -759,9 +772,9 @@ mutual
   -- D_data decodes maps as definite-only, so this EXTENDS the decoder beyond the spec to the
   -- indefinite form Data.hs also accepts (decodeMapLenOrIndef). Decode-only, the encoder still
   -- emits only definite maps.
-  partial def decodePairListIndef : List Char → Option (List Char × List (Data × Data))
-    | '\xFF' :: s' => .some (s', [])
-    | s            => match decodeDataLoop s with
+  partial def decodePairListIndef : List UInt8 → Option (List UInt8 × List (Data × Data))
+    | 0xFF :: s' => .some (s', [])
+    | s          => match decodeDataLoop s with
         | some (s', k) => match decodeDataLoop s' with
             | some (s'', v) => match decodePairListIndef s'' with
                 | some (s''', l) => some (s''', (k, v) :: l)
@@ -772,24 +785,24 @@ mutual
   -- Decode a constructor whose tag-102 wrapper uses the INDEFINITE 2-element array
   -- (0x9f index args 0xff), the form Data.hs accepts via decodeListLenOrIndef. The canonical
   -- encoder never emits it, so this is decode-only leniency toward the reference implementation.
-  partial def decodeIndefConstr (s : List Char) : Option (List Char × Data) :=
+  partial def decodeIndefConstr (s : List UInt8) : Option (List UInt8 × Data) :=
     match decodeHead s with
     | .some (s', 6, 102) => match decodeIndef s' with
         | .some (s'', 4) => match decodeHead s'' with
             | .some (s3, 0, iv) => match decodeAlternative decodeIndef decodeHead s3 with
                 | .some (s4, .inl 4     ) => match decodeListIndef s4 with
-                    | .some ('\xFF' :: s6, args) => .some (s6, .Constr (Int.ofNat iv) args)
-                    | _                          => .none
+                    | .some (0xFF :: s6, args) => .some (s6, .Constr (Int.ofNat iv) args)
+                    | _                        => .none
                 | .some (s4, .inr (4, n)) => match decodeList n s4 with
-                    | .some ('\xFF' :: s6, args) => .some (s6, .Constr (Int.ofNat iv) args)
-                    | _                          => .none
+                    | .some (0xFF :: s6, args) => .some (s6, .Constr (Int.ofNat iv) args)
+                    | _                        => .none
                 | _                       => .none
             | _ => .none
         | _ => .none
     | _ => .none
 
   -- Decode a constructor (Constr tag + list of Data values)
-  partial def decodeConstr (s : List Char) : Option (List Char × Data) :=
+  partial def decodeConstr (s : List UInt8) : Option (List UInt8 × Data) :=
     match decodeCtag s with
     | some (s', i) => match decodeAlternative decodeIndef decodeHead s' with
         | some (s'', r) => match r with
@@ -800,12 +813,12 @@ mutual
     | none => decodeIndefConstr s
 end
 
-/- Decodes a builtin data from input `s`. -/
+/- Decodes a builtin data from input `b`. -/
 -- Spec B.7. D_data, EXTENDED beyond the spec on two indefinite-length forms the spec rejects but
 -- Data.hs accepts: indefinite maps (decodePairListIndef) and the indefinite tag-102 constructor
 -- wrapper (decodeIndefConstr). Decode-only, the encoder is unchanged.
-def decodeData (s : String) : Option (String × Data) :=
-  Prod.map String.mk id <$> decodeDataLoop s.data
+def decodeData (b : ByteArray) : Option (ByteArray × Data) :=
+  (decodeDataLoop b.toList).map (fun (rem, d) => (rem.toByteArray, d))
 
 end CborInternal
 
@@ -815,6 +828,8 @@ export CborInternal
     encodeInt
     encodeData
     -- decoding
+    bytesToByteString
+    byteArrayToByteString
     decodeBytestring
     decodeLargeBytestring
     decodeInt

--- a/PlutusCore/Cbor/Basic.lean
+++ b/PlutusCore/Cbor/Basic.lean
@@ -25,114 +25,117 @@ def b_ (i n : Nat) : UInt8 := ((n / (256 ^ i)) % 256).toUInt8
 /-- e_w: Returns the little-endian encoding of natural numbers in the prescribed width.
     In CBOR only the forms e₁ e₂ e₄ and e₈ are used. -/
 -- Spec B.4. 𝖾_𝑘(𝑛) = [𝖻_(𝑘−1)(𝑛), … , 𝖻_0(𝑛)] if 𝑛 ≤ 256 ^ 𝑘 − 1.
-@[simp] def e₁ (n : Nat) : List UInt8 := [b_ 0 n]
-@[simp] def e₂ (n : Nat) : List UInt8 := [b_ 1 n, b_ 0 n]
-@[simp] def e₄ (n : Nat) : List UInt8 := [b_ 3 n, b_ 2 n, b_ 1 n, b_ 0 n]
-@[simp] def e₈ (n : Nat) : List UInt8 := [b_ 7 n, b_ 6 n, b_ 5 n, b_ 4 n, b_ 3 n, b_ 2 n, b_ 1 n, b_ 0 n]
+@[simp] def e₁ (n : Nat) : ByteArray := ⟨#[b_ 0 n]⟩
+@[simp] def e₂ (n : Nat) : ByteArray := ⟨#[b_ 1 n, b_ 0 n]⟩
+@[simp] def e₄ (n : Nat) : ByteArray := ⟨#[b_ 3 n, b_ 2 n, b_ 1 n, b_ 0 n]⟩
+@[simp] def e₈ (n : Nat) : ByteArray := ⟨#[b_ 7 n, b_ 6 n, b_ 5 n, b_ 4 n, b_ 3 n, b_ 2 n, b_ 1 n, b_ 0 n]⟩
 
 /-- ε_head: Encodes the major type (`m`) × Nat pair -/
 -- Spec B.4.
-def encodeHead (m n : Nat) : Option (List UInt8) :=
+def encodeHead (m n : Nat) : Option ByteArray :=
   if m ≤ 7 then
-         if n ≤                   23 then .some [(32 * m + n ).toUInt8]
-    else if n ≤                  255 then .some ((32 * m + 24).toUInt8 :: e₁ n)
-    else if n ≤                65535 then .some ((32 * m + 25).toUInt8 :: e₂ n)
-    else if n ≤           4294967295 then .some ((32 * m + 26).toUInt8 :: e₄ n)
-    else if n ≤ 18446744073709551615 then .some ((32 * m + 27).toUInt8 :: e₈ n)
+         if n ≤                   23 then .some  ⟨#[(32 * m + n ).toUInt8]⟩
+    else if n ≤                  255 then .some (⟨#[(32 * m + 24).toUInt8]⟩ ++ e₁ n)
+    else if n ≤                65535 then .some (⟨#[(32 * m + 25).toUInt8]⟩ ++ e₂ n)
+    else if n ≤           4294967295 then .some (⟨#[(32 * m + 26).toUInt8]⟩ ++ e₄ n)
+    else if n ≤ 18446744073709551615 then .some (⟨#[(32 * m + 27).toUInt8]⟩ ++ e₈ n)
     else .none
   else .none
 
 /-- Splitting a byte list into 64-byte chunks. -/
 -- Spec B.5. "Canonical 64-byte decomposition"
-def splitToChunks : List UInt8 → List (List UInt8) :=
-  let rec loop acc s :=
-    if _ : s = [] then List.reverse acc
-                  else loop (List.take 64 s :: acc) (List.drop 64 s)
-    termination_by s.length
-    decreasing_by
-      have hne : s ≠ [] := by assumption
-      cases s with
-      | nil => exact absurd rfl hne
-      | cons _ _ =>
-        simp [List.length_drop]
-        omega
-  loop []
+def splitToChunks (b : ByteArray) : List ByteArray :=
+  let length := b.size
+  if length == 0
+    then []
+    else
+      let chunksCount := ((length - 1) / 64) + 1
+      (List.range chunksCount).map (λ ix =>
+        b.extract (ix * 64) ((ix + 1) * 64)
+      )
 
 /-- Some sequences are encoded without a specified length (indefinite length encoding). -/
 -- Spec B.4. Heads for indefinite-length items.
-def encodeIndef (m : Nat) : UInt8 := (32 * m + 31).toUInt8
+def encodeIndef (m : Nat) : ByteArray := ⟨#[(32 * m + 31).toUInt8]⟩
 
 /-- Encodes a bytestring chunk. -/
 -- Spec B.5. ε_B*
-def encodeBytestringChunk (s : List UInt8) : Option (List UInt8) := do
-  let length := s.length
+def encodeBytestringChunk (s : ByteArray) : Option ByteArray := do
+  let length := s.size
   if length ≤ 256 ^ 8
     then .some ((←encodeHead 2 length) ++ s)
     else .none
 
-/-- Encodes a bytestring (internal, list-based).
+/-- Encodes a bytestring.
     First splits the byte list into 64-byte chunks as detailed in the specification. -/
 -- Spec B.5. ε_B*
-def encodeBytestringL (s : List UInt8) : Option (List UInt8) :=
+def encodeBytestring (s : ByteArray) : Option ByteArray :=
   match splitToChunks s with
   | []      => encodeHead 2 0   -- empty bytestring is a definite 0-length string (0x40)
   | h :: [] => encodeBytestringChunk h
-  | chunks  => do .some (encodeIndef 2 :: (List.concat (←List.flatMapM encodeBytestringChunk chunks) 0xFF))
+  | chunks  => do .some (encodeIndef 2
+                 ++ (←(List.foldl ByteArray.append .empty) <$> (List.mapM id (encodeBytestringChunk <$> chunks))).push 0xFF)
 
 /-- Encodes a natural number as a list of bytes in big-endian. -/
 -- Spec B.6. itos
-def itos (n : Nat) : List UInt8 :=
-  if n == 0
-    then []
-    else itos (n / 256) ++ [(n % 256).toUInt8]
+def itos (n : Nat) : ByteArray :=
+  let rec loop (acc : ByteArray) (n : Nat) :=
+    if h : n == 0
+      then acc
+      else loop (acc.push (n % 256).toUInt8) (n / 256)
+  termination_by n
   decreasing_by
     apply Nat.div_lt_self
-    · have h : ¬(n == 0) = true := by assumption
-      simp at h
-      omega
+    · simp at h; omega
     · omega
+  loop .empty n
 
-/-- Encodes an integer using zigzag encoding (internal, list-based). -/
+/-- Encodes an integer using zigzag encoding. -/
 -- Spec B.6. ε_Z
-def encodeIntL (n : Integer) : Option (List UInt8) :=
+def encodeInt (n : Integer) : Option ByteArray :=
        if (                    0 ≤ n) && (n ≤  18446744073709551615) then encodeHead 0 (Int.toNat n)
-  else if ( 18446744073709551616 ≤ n)                                then do return (←encodeHead 6 2) ++ (←encodeBytestringL (itos (Int.toNat n)))
+  else if ( 18446744073709551616 ≤ n)                                then do return (←encodeHead 6 2) ++ (←encodeBytestring (itos (Int.toNat n)))
   else if (-18446744073709551616 ≤ n) && (n ≤                    -1) then encodeHead 1 ((-n - 1) |> Int.toNat)
-  else if                                (n ≤ -18446744073709551617) then do return (←encodeHead 6 3) ++ (←encodeBytestringL (itos (Int.toNat (-n - 1))))
+  else if                                (n ≤ -18446744073709551617) then do return (←encodeHead 6 3) ++ (←encodeBytestring (itos (Int.toNat (-n - 1))))
   else .none
 
-/-- Encodes a ctag (internal, list-based). -/
+/-- Encodes a ctag. -/
 -- Spec B.7. ε_ctag
-def encodeCtagL (i : Integer) : Option (List UInt8) :=
+def encodeCtag (i : Integer) : Option ByteArray :=
        if (0 ≤ i) && (i ≤   6) then encodeHead 6 ( 121 + i       |> Int.toNat)
   else if (7 ≤ i) && (i ≤ 127) then encodeHead 6 (1280 + (i - 7) |> Int.toNat)
-  else do return (←encodeHead 6 102) ++ (←encodeHead 4 2) ++ (←encodeIntL i)
+  else do return (←encodeHead 6 102) ++ (←encodeHead 4 2) ++ (←encodeInt i)
 
-/-- Encode data (builtinData) (internal, list-based). -/
+/-- Converts a UPLC `ByteString` (which wraps a `String` of codepoint-as-byte
+    chars) to its `ByteArray` representation. -/
+@[inline] def byteStringToByteArray (bs : ByteString) : ByteArray :=
+  (Char.toUInt8 <$> bs.data.data).toByteArray
+
+/-- Encode data (builtinData). -/
 -- Spec B.7. Encoding and  decoding Data. ε_data
-def encodeDataL : Data → Option (List UInt8)
+def encodeData : Data → Option ByteArray
   | .Constr idx fields =>
       if fields.isEmpty then do
         -- empty field list is a DEFINITE empty array (0x80), matching the serialiseData builtin
-        (←encodeCtagL idx) ++ (←encodeHead 4 0)
+        (←encodeCtag idx) ++ (←encodeHead 4 0)
       else do
-        (←encodeCtagL idx)
-        ++ [encodeIndef 4]
-        ++ (←List.foldlM (λ s a => do .some (s ++ (←encodeDataL a))) [] fields)
-        ++ [UInt8.ofNat 0xFF]
+        (←encodeCtag idx)
+        ++ encodeIndef 4
+        ++ (←List.foldlM (λ s a => do .some (s ++ (←encodeData a))) .empty fields)
+        ++ ByteArray.mk #[0xFF]
   | .Map mxs => do
       (←encodeHead 5 mxs.length)
-      ++ (←List.foldlM (λ s p => do .some (s ++ (←encodeDataL p.fst) ++ (←encodeDataL p.snd))) [] mxs)
+      ++ (←List.foldlM (λ s p => do .some (s ++ (←encodeData p.fst) ++ (←encodeData p.snd))) .empty mxs)
   | .List xs =>
       if xs.isEmpty then
         -- empty list is a DEFINITE empty array (0x80), matching the serialiseData builtin
         encodeHead 4 0
       else do
-        [encodeIndef 4]
-        ++ (←List.foldlM (λ s a => do .some (s ++ (←encodeDataL a))) [] xs)
-        ++ [UInt8.ofNat 0xFF]
-  | .I i  => encodeIntL i
-  | .B bs => encodeBytestringL (Char.toUInt8 <$> bs.data.data)
+        encodeIndef 4
+        ++ (←List.foldlM (λ s a => do .some (s ++ (←encodeData a))) .empty xs)
+        ++ ByteArray.mk #[0xFF]
+  | .I i  => encodeInt i
+  | .B bs => encodeBytestring (byteStringToByteArray bs)
 
   decreasing_by
     · have : sizeOf a     < sizeOf fields := by apply List.sizeOf_lt_of_mem; assumption
@@ -146,34 +149,27 @@ def encodeDataL : Data → Option (List UInt8)
     · have : sizeOf a     < sizeOf xs     := by apply List.sizeOf_lt_of_mem; assumption
       simp; omega
 
-/-- Converts a UPLC `ByteString` (which wraps a `String` of codepoint-as-byte
-    chars) to its `ByteArray` representation. -/
-@[inline] def byteStringToByteArray (bs : ByteString) : ByteArray :=
-  (Char.toUInt8 <$> bs.data.data).toByteArray
-
-/-- Encodes a bytestring. -/
--- Spec B.5. ε_B*
-@[inline] def encodeBytestring (b : ByteArray) : Option ByteArray :=
-  (encodeBytestringL b.toList).map List.toByteArray
-
-/-- Encodes an integer using zigzag encoding. -/
--- Spec B.6. ε_Z
-@[inline] def encodeInt (n : Integer) : Option ByteArray :=
-  (encodeIntL n).map List.toByteArray
-
-/-- Encodes a ctag. -/
--- Spec B.7. ε_ctag
-@[inline] def encodeCtag (i : Integer) : Option ByteArray :=
-  (encodeCtagL i).map List.toByteArray
-
-/-- Encode data (builtinData). -/
--- Spec B.7. Encoding and decoding Data. ε_data
-@[inline] def encodeData (d : Data) : Option ByteArray :=
-  (encodeDataL d).map List.toByteArray
-
 -- ==============
 -- =  Decoding  =
 -- ==============
+
+/-- A cursor into a `ByteArray`: the immutable input buffer plus the current read position. -/
+structure DecodeState where
+  input : ByteArray
+  pos   : Nat
+deriving DecidableEq
+
+/-- Advances the cursor `n` bytes (default 1). -/
+def DecodeState.advance (d : DecodeState) (n : Nat := 1) : DecodeState :=
+  { d with pos := d.pos + n }
+
+def DecodeState.nextUInt8 (d : DecodeState) (skip : Nat := 0) : Option UInt8 := d.input[d.pos + skip]?
+
+@[simp] theorem DecodeState.advance_input (d : DecodeState) (n : Nat) :
+    (d.advance n).input = d.input := rfl
+
+@[simp] theorem DecodeState.advance_pos (d : DecodeState) (n : Nat) :
+    (d.advance n).pos = d.pos + n := rfl
 
 /-- Wrap a list of bytes into the UPLC `ByteString` domain value.
     `ByteString` is intentionally a wrapper around `String` (Haskell-compat),
@@ -187,547 +183,689 @@ def encodeDataL : Data → Option (List UInt8)
   bytesToByteString b.toList
 
 /-- Helper function that is used in reconstructing natural numbers from their big endian representation -/
-def d_ (i : Nat) (c : UInt8) := c.toNat * (256 ^ i)
+def d_ (i : Nat) (c : UInt8) : Nat := c.toNat * (256 ^ i)
+
+/-- Reading byte `i` from an array succeeds only when `i` is in bounds. -/
+private theorem getElem?_some_lt {a : Array UInt8} {i : Nat} {b : UInt8} (h : a[i]? = some b) :
+  i < a.size := by
+    by_cases hlt : i < a.size
+    · exact hlt
+    · have hge : a.size ≤ i := Nat.le_of_not_lt hlt
+      rw [Array.getElem?_eq_none hge] at h
+      exact Option.noConfusion h
+
+/-- Reading byte `i` from a `ByteArray` succeeds only when `i` is in bounds. -/
+private theorem bytes_lt_of_byte {b : ByteArray} {i : Nat} {u : UInt8} (h : b.data[i]? = some u) :
+  i < b.size := getElem?_some_lt h
+
+/-- `d.nextUInt8 skip` succeeds only when `d.pos + skip` is in bounds. -/
+private theorem DecodeState.nextUInt8_some_lt {d : DecodeState} {skip : Nat} {b : UInt8} (h : d.nextUInt8 skip = some b) :
+  d.pos + skip < d.input.size := by
+    have h' : d.input.data[d.pos + skip]? = some b := h
+    exact bytes_lt_of_byte h'
 
 -- Spec B.4. The `d_k` function is a general function to reconstruct a `k` byte natural number
 -- from its big endian representation. In the spec only the forms with k = 1, 2, 4 and 8 are used.
 /-- Decodes a one byte integer. -/
-def d₁ : List UInt8 → Option (List UInt8 × Nat)
-  | b :: t => .some (t, b.toNat)
-  | []     => .none
+def d₁ (d : DecodeState) : Option (DecodeState × Nat) :=
+  match d.nextUInt8 with
+  | some b => .some (d.advance, b.toNat)
+  | none   => .none
 
 /-- Decodes a two byte integer. -/
-def d₂ : List UInt8 → Option (List UInt8 × Nat)
-  | b₁ :: b₀ :: t => .some (t, d_ 1 b₁ + d_ 0 b₀)
-  | _             => .none
+def d₂ (d : DecodeState) : Option (DecodeState × Nat) := do
+  let b₁ ← d.nextUInt8 0
+  let b₀ ← d.nextUInt8 1
+  some (d.advance 2, d_ 1 b₁ + d_ 0 b₀)
 
 /-- Decodes a four byte integer. -/
-def d₄ : List UInt8 → Option (List UInt8 × Nat)
-  | b₃ :: b₂ :: b₁ :: b₀ :: t => .some (t, d_ 3 b₃ + d_ 2 b₂ + d_ 1 b₁ + d_ 0 b₀)
-  | _                         => .none
+def d₄ (d : DecodeState) : Option (DecodeState × Nat) := do
+  let b₃ ← d.nextUInt8 0
+  let b₂ ← d.nextUInt8 1
+  let b₁ ← d.nextUInt8 2
+  let b₀ ← d.nextUInt8 3
+  some (d.advance 4, d_ 3 b₃ + d_ 2 b₂ + d_ 1 b₁ + d_ 0 b₀)
 
 /-- Decodes an eight byte integer. -/
-def d₈ : List UInt8 → Option (List UInt8 × Nat)
-  | b₇ :: b₆ :: b₅ :: b₄ :: b₃ :: b₂ :: b₁ :: b₀ :: t => .some (t, d_ 7 b₇ + d_ 6 b₆ + d_ 5 b₅ + d_ 4 b₄ + d_ 3 b₃ + d_ 2 b₂ + d_ 1 b₁ + d_ 0 b₀)
-  | _                                                 => .none
+def d₈ (d : DecodeState) : Option (DecodeState × Nat) := do
+  let b₇ ← d.nextUInt8 0
+  let b₆ ← d.nextUInt8 1
+  let b₅ ← d.nextUInt8 2
+  let b₄ ← d.nextUInt8 3
+  let b₃ ← d.nextUInt8 4
+  let b₂ ← d.nextUInt8 5
+  let b₁ ← d.nextUInt8 6
+  let b₀ ← d.nextUInt8 7
+  some (d.advance 8, d_ 7 b₇ + d_ 6 b₆ + d_ 5 b₅ + d_ 4 b₄ + d_ 3 b₃ + d_ 2 b₂ + d_ 1 b₁ + d_ 0 b₀)
 
 /-- Decodes a "head" structure that describes how the next bytes should be interpreted. -/
 -- Spec B.4. D_head
-def decodeHead : List UInt8 → Option ((List UInt8) × Nat × Nat)
-  | n' :: s =>
-      let n := n'.toNat
-      let d := n / 32
-      match n % 32 with
-      | 24 => (λ (s', k) => (s', d, k)) <$> d₁ s
-      | 25 => (λ (s', k) => (s', d, k)) <$> d₂ s
-      | 26 => (λ (s', k) => (s', d, k)) <$> d₄ s
-      | 27 => (λ (s', k) => (s', d, k)) <$> d₈ s
-      | m  => if m ≤ 23 then .some (s, d, m)
-                        else .none
-  | _ => .none
+def decodeHead (d : DecodeState) : Option (DecodeState × Nat × Nat) :=
+  match d.nextUInt8 with
+  | none    => .none
+  | some n' =>
+      match n'.toNat % 32 with
+      | 24 => (λ (d', k) => (d', n'.toNat / 32, k)) <$> d₁ d.advance
+      | 25 => (λ (d', k) => (d', n'.toNat / 32, k)) <$> d₂ d.advance
+      | 26 => (λ (d', k) => (d', n'.toNat / 32, k)) <$> d₄ d.advance
+      | 27 => (λ (d', k) => (d', n'.toNat / 32, k)) <$> d₈ d.advance
+      | m  => if m ≤ 23 then .some (d.advance, n'.toNat / 32, m) else .none
 
 /-- Decodes a "head" structure with indefinite length that describes how the next bytes should be interpreted. -/
 -- Spec B.4. D_indef
-def decodeIndef : List UInt8 → Option (List UInt8 × Nat)
-  | n' :: s =>
+def decodeIndef (d : DecodeState) : Option (DecodeState × Nat) :=
+  match d.nextUInt8 with
+  | some n' =>
       let n := n'.toNat
-      if n % 32 = 31
-        then .some (s, n / 32)
-        else .none
-  | [] => .none
-
-def decodeBytesLoop (acc : List UInt8) : Nat → List UInt8 → Option (List UInt8 × List UInt8)
-  | .zero  , s       => .some (s, (List.reverse acc))
-  | .succ _, []      => .none
-  | .succ p, b :: s' => decodeBytesLoop (b :: acc) p s'
+      if n % 32 = 31 then .some (d.advance, n / 32) else .none
+  | none    => .none
 
 /-- Decodes (consumes) the next `n` bytes from the input. -/
 -- Spec B.5. D_bytes
-def decodeBytes := decodeBytesLoop []
+def decodeBytes (d : DecodeState) (n : Nat) : Option (DecodeState × ByteArray) :=
+  if d.pos + n ≤ d.input.size
+    then .some (d.advance n, d.input.extract d.pos (d.pos + n))
+    else .none
 
 /-- Decodes a definite length "block" (bytestring chunk). -/
 -- Spec B.5. D_block
-def decodeBlock (s : List UInt8) : Option (List UInt8 × List UInt8) := do
-  let (s', m, n) ← decodeHead s
+def decodeBlock (d : DecodeState) : Option (DecodeState × ByteArray) := do
+  let (d', m, n) ← decodeHead d
   if m = 2 ∧ n ≤ 64
-    then decodeBytes n s'
+    then decodeBytes d' n
     else .none
 
 -- ==========================
 -- = Termination Helpers    =
 -- ==========================
 
-/-- Helper theorem: decodeHead always consumes at least one byte on success -/
-theorem decodeHead_consumes (s : List UInt8) :
-  ∀ s' d k, decodeHead s = some (s', d, k) → s'.length < s.length := by
-  intro s' d k h
-  unfold decodeHead at h
-  cases s with
-  | nil => simp at h
-  | cons n' t =>
-    simp at h
+/-- `d₁` advances `pos` by exactly 1 on success. -/
+theorem d₁_consumes (d : DecodeState) :
+  ∀ d' k, d₁ d = some (d', k) → d'.input = d.input ∧ d'.pos = d.pos + 1 ∧ d'.pos ≤ d.input.size := by
+    intro d' k h
+    unfold d₁ at h
     split at h
-    · -- Case: n % 32 = 24, uses d₁
-      simp [Option.map_eq_some_iff, d₁] at h
-      obtain ⟨b, heq⟩ := h
-      cases t with
-      | nil => simp at heq
-      | cons c t' =>
-        simp at heq
-        obtain ⟨h1, h2, h3, h4, h5⟩ := heq
-        obtain ⟨h2a, h2b⟩ := h2
-        rw [← h3, ← h2a]
-        simp; omega
-    · -- Case: n % 32 = 25, uses d₂
-      simp [Option.map_eq_some_iff, d₂] at h
-      obtain ⟨b, heq⟩ := h
-      cases t with
-      | nil => simp at heq
-      | cons c1 t1 =>
-        cases t1 with
-        | nil => simp at heq
-        | cons c0 t' =>
-          simp at heq
-          obtain ⟨h1, h2, h3, h4, h5⟩ := heq
-          obtain ⟨h2a, h2b⟩ := h2
-          rw [← h3, ← h2a]
-          simp; omega
-    · -- Case: n % 32 = 26, uses d₄
-      simp [Option.map_eq_some_iff, d₄] at h
-      obtain ⟨b, heq⟩ := h
-      cases t with
-      | nil => simp at heq
-      | cons c3 t3 =>
-        cases t3 with
-        | nil => simp at heq
-        | cons c2 t2 =>
-          cases t2 with
-          | nil => simp at heq
-          | cons c1 t1 =>
-            cases t1 with
-            | nil => simp at heq
-            | cons c0 t' =>
-              simp at heq
-              obtain ⟨h1, h2, h3, h4, h5⟩ := heq
-              obtain ⟨h2a, h2b⟩ := h2
-              rw [← h3, ← h2a]
-              simp; omega
-    · -- Case: n % 32 = 27, uses d₈
-      simp [Option.map_eq_some_iff, d₈] at h
-      obtain ⟨b, heq⟩ := h
-      cases t with
-      | nil => simp at heq
-      | cons c7 t7 =>
-        cases t7 with
-        | nil => simp at heq
-        | cons c6 t6 =>
-          cases t6 with
-          | nil => simp at heq
-          | cons c5 t5 =>
-            cases t5 with
-            | nil => simp at heq
-            | cons c4 t4 =>
-              cases t4 with
-              | nil => simp at heq
-              | cons c3 t3 =>
-                cases t3 with
-                | nil => simp at heq
-                | cons c2 t2 =>
-                  cases t2 with
-                  | nil => simp at heq
-                  | cons c1 t1 =>
-                    cases t1 with
-                    | nil => simp at heq
-                    | cons c0 t' =>
-                      simp at heq
-                      obtain ⟨h1, h2, h3, h4, h5⟩ := heq
-                      obtain ⟨h2a, h2b⟩ := h2
-                      rw [← h3, ← h2a]
-                      simp; omega
-    · -- Case: m ≤ 23
+    case h_1 b hget =>
+      simp at h
+      obtain ⟨h1, _⟩ := h
+      subst h1
+      have := DecodeState.nextUInt8_some_lt hget
+      refine ⟨rfl, rfl, ?_⟩
+      show d.pos + 1 ≤ d.input.size
+      omega
+    case h_2 => simp at h
+
+/-- `d₂` advances `pos` by exactly 2 on success. -/
+theorem d₂_consumes (d : DecodeState) :
+  ∀ d' k, d₂ d = some (d', k) → d'.input = d.input ∧ d'.pos = d.pos + 2 ∧ d'.pos ≤ d.input.size := by
+    intro d' k h
+    unfold d₂ at h
+    rcases hb1 : d.nextUInt8 with _ | b₁
+    · simp [hb1] at h
+    rcases hb0 : d.nextUInt8 1 with _ | b₀
+    · simp [hb1, hb0] at h
+    simp [hb1, hb0] at h
+    obtain ⟨h1, _⟩ := h
+    subst h1
+    have := DecodeState.nextUInt8_some_lt hb0
+    refine ⟨rfl, rfl, ?_⟩
+    show d.pos + 2 ≤ d.input.size
+    omega
+
+/-- `d₄` advances `pos` by exactly 4 on success. -/
+theorem d₄_consumes (d : DecodeState) :
+  ∀ d' k, d₄ d = some (d', k) → d'.input = d.input ∧ d'.pos = d.pos + 4 ∧ d'.pos ≤ d.input.size := by
+    intro d' k h
+    unfold d₄ at h
+    rcases hb3 : d.nextUInt8     with _ | b₃
+    · simp [hb3] at h
+    rcases hb2 : d.nextUInt8 1   with _ | b₂
+    · simp [hb3, hb2] at h
+    rcases hb1 : d.nextUInt8 2   with _ | b₁
+    · simp [hb3, hb2, hb1] at h
+    rcases hb0 : d.nextUInt8 3   with _ | b₀
+    · simp [hb3, hb2, hb1, hb0] at h
+    simp [hb3, hb2, hb1, hb0] at h
+    obtain ⟨h1, _⟩ := h
+    subst h1
+    have := DecodeState.nextUInt8_some_lt hb0
+    refine ⟨rfl, rfl, ?_⟩
+    show d.pos + 4 ≤ d.input.size
+    omega
+
+/-- `d₈` advances `pos` by exactly 8 on success. -/
+theorem d₈_consumes (d : DecodeState) :
+  ∀ d' k, d₈ d = some (d', k) → d'.input = d.input ∧ d'.pos = d.pos + 8 ∧ d'.pos ≤ d.input.size := by
+    intro d' k h
+    unfold d₈ at h
+    rcases hb7 : d.nextUInt8     with _ | b₇
+    · simp [hb7] at h
+    rcases hb6 : d.nextUInt8 1   with _ | b₆
+    · simp [hb7, hb6] at h
+    rcases hb5 : d.nextUInt8 2   with _ | b₅
+    · simp [hb7, hb6, hb5] at h
+    rcases hb4 : d.nextUInt8 3   with _ | b₄
+    · simp [hb7, hb6, hb5, hb4] at h
+    rcases hb3 : d.nextUInt8 4   with _ | b₃
+    · simp [hb7, hb6, hb5, hb4, hb3] at h
+    rcases hb2 : d.nextUInt8 5   with _ | b₂
+    · simp [hb7, hb6, hb5, hb4, hb3, hb2] at h
+    rcases hb1 : d.nextUInt8 6   with _ | b₁
+    · simp [hb7, hb6, hb5, hb4, hb3, hb2, hb1] at h
+    rcases hb0 : d.nextUInt8 7   with _ | b₀
+    · simp [hb7, hb6, hb5, hb4, hb3, hb2, hb1, hb0] at h
+    simp [hb7, hb6, hb5, hb4, hb3, hb2, hb1, hb0] at h
+    obtain ⟨h1, _⟩ := h
+    subst h1
+    have := DecodeState.nextUInt8_some_lt hb0
+    refine ⟨rfl, rfl, ?_⟩
+    show d.pos + 8 ≤ d.input.size
+    omega
+
+/-- Helper for the four width-prefixed branches of `decodeHead`. -/
+private theorem decodeHead_di_branch_consumes {d d' : DecodeState} {n' : UInt8} {dv k δ : Nat}
+  {dx : DecodeState → Option (DecodeState × Nat)}
+  (hdx_cons : ∀ d₀ k₀, dx d.advance = some (d₀, k₀) → d₀.input = (d.advance).input ∧ d₀.pos = (d.advance).pos + δ ∧ d₀.pos ≤ (d.advance).input.size)
+  (h : (fun (p : DecodeState × Nat) => (p.1, n'.toNat / 32, p.2)) <$> dx d.advance = some (d', dv, k)) :
+  d'.input = d.input ∧ d'.pos > d.pos ∧ d'.pos ≤ d.input.size := by
+    rcases hdx : dx d.advance with _ | ⟨d_st, n_val⟩
+    · rw [hdx] at h; simp at h
+    rw [hdx] at h; simp at h
+    obtain ⟨h_d', _, _⟩ := h
+    have ⟨hin, hpos, hle⟩ := hdx_cons d_st n_val hdx
+    simp at hin hpos hle
+    subst h_d'
+    refine ⟨hin, ?_, hle⟩
+    omega
+
+/-- `decodeHead` advances `pos` by at least 1 on success. -/
+theorem decodeHead_consumes (d : DecodeState) :
+  ∀ d' dv k, decodeHead d = some (d', dv, k) → d'.input = d.input ∧ d'.pos > d.pos ∧ d'.pos ≤ d.input.size := by
+    intro d' dv k h
+    unfold decodeHead at h
+    rcases hget : d.nextUInt8 with _ | n'
+    · simp only [hget] at h
+      exact Option.noConfusion h
+    simp only [hget] at h
+    have hposlt : d.pos < d.input.size := by
+      have := DecodeState.nextUInt8_some_lt hget
+      omega
+    split at h
+    case h_1 _ => exact decodeHead_di_branch_consumes (d₁_consumes _) h
+    case h_2 _ => exact decodeHead_di_branch_consumes (d₂_consumes _) h
+    case h_3 _ => exact decodeHead_di_branch_consumes (d₄_consumes _) h
+    case h_4 _ => exact decodeHead_di_branch_consumes (d₈_consumes _) h
+    case h_5 m _ =>
       split at h
       · simp at h
-        obtain ⟨h1, h2, h3⟩ := h
-        rw [← h1]
-        simp
+        obtain ⟨h_d', _, _⟩ := h
+        subst h_d'
+        refine ⟨rfl, ?_, ?_⟩
+        · show d.pos + 1 > d.pos; omega
+        · show d.pos + 1 ≤ d.input.size; omega
       · simp at h
 
-/-- Helper theorem: decodeBytesLoop consumes exactly n bytes regardless of accumulator -/
-theorem decodeBytesLoop_consumes : ∀ (acc : List UInt8) (n : Nat) (s : List UInt8) (s' t : List UInt8),
-  decodeBytesLoop acc n s = some (s', t) → s'.length + n = s.length := by
-  intro acc n s s' t h
-  revert acc s s' t
-  induction n with
-  | zero =>
-    intro acc s s' t h
-    unfold decodeBytesLoop at h
-    simp at h
-    obtain ⟨h1, _⟩ := h
-    rw [← h1]; simp
-  | succ p ih =>
-    intro acc s s' t h
-    cases s with
-    | nil => unfold decodeBytesLoop at h; simp at h
-    | cons b s'' =>
-      unfold decodeBytesLoop at h
-      have ih_result := ih (b :: acc) s'' s' t h
-      simp
-      calc s'.length + (p + 1)
-        = s'.length + p + 1 := by omega
-        _ = s''.length + 1 := by rw [ih_result]
-
-/-- Helper theorem: decodeBytes consumes exactly n bytes on success -/
-theorem decodeBytes_consumes (n : Nat) (s : List UInt8) :
-  ∀ s' t, decodeBytes n s = some (s', t) → s'.length + n = s.length := by
-  intro s' t h
-  unfold decodeBytes at h
-  exact decodeBytesLoop_consumes [] n s s' t h
-
-/-- Helper theorem: decodeBlock consumes at least one byte on success -/
-theorem decodeBlock_consumes (s : List UInt8) :
-  ∀ s' t, decodeBlock s = some (s', t) → s'.length < s.length := by
-  intro s' t h
-  unfold decodeBlock at h
-  simp only [Option.bind_eq_bind, Option.bind_eq_some_iff] at h
-  obtain ⟨⟨s'', m, n⟩, hdh, h⟩ := h
-  split at h
-  · have h_head := decodeHead_consumes s s'' m n hdh
-    have h_bytes := decodeBytes_consumes n s'' s' t h
-    omega
-  · simp at h
-
-/-- Helper theorem: decodeIndef consumes exactly one byte on success -/
-theorem decodeIndef_consumes (s : List UInt8) :
-  ∀ s' n, decodeIndef s = some (s', n) → s'.length + 1 = s.length := by
-  intro s' n h
-  unfold decodeIndef at h
-  cases s with
-  | nil => simp at h
-  | cons head tail =>
+/-- `decodeIndef` advances `pos` by exactly 1 on success. -/
+theorem decodeIndef_consumes (d : DecodeState) :
+  ∀ d' n, decodeIndef d = some (d', n) → d'.input = d.input ∧ d'.pos = d.pos + 1 ∧ d'.pos ≤ d.input.size := by
+    intro d' n h
+    unfold decodeIndef at h
+    rcases hb : d.nextUInt8 with _ | b
+    · simp [hb] at h
+    simp only [hb] at h
     split at h
-    · rename_i b t heq
-      simp at h
-      obtain ⟨h1, h2⟩ := h
-      obtain ⟨h2a, h2b⟩ := h2
-      subst h2a
-      cases heq
-      simp
+    · simp at h
+      obtain ⟨hd', _⟩ := h
+      subst hd'
+      have := DecodeState.nextUInt8_some_lt hb
+      refine ⟨rfl, rfl, ?_⟩
+      show d.pos + 1 ≤ d.input.size
+      omega
     · simp at h
 
-set_option linter.unusedVariables false
+/-- `decodeBytes` advances `pos` by exactly `n` on success. -/
+theorem decodeBytes_consumes (d : DecodeState) (n : Nat) :
+  ∀ d' t, decodeBytes d n = some (d', t) → d'.input = d.input ∧ d'.pos = d.pos + n ∧ d'.pos ≤ d.input.size := by
+    intro d' t h
+    unfold decodeBytes at h
+    split at h
+    · simp at h
+      obtain ⟨h1, _⟩ := h
+      subst h1
+      refine ⟨rfl, rfl, ?_⟩
+      show d.pos + n ≤ d.input.size
+      assumption
+    · simp at h
 
-def decodeBlocksLoop (acc : List UInt8) : (s : List UInt8) → Option (List UInt8 × List UInt8)
-  | 0xFF :: s' => .some (s', List.reverse acc)
-  | s => match h : decodeBlock s with
-      | some (s', t) => decodeBlocksLoop ((List.reverse t) ++ acc) s'
-      | none => none
-termination_by s => s.length
-decreasing_by
-  simp_wf
-  have : s'.length < s.length := decodeBlock_consumes s s' t h
-  exact this
+/-- `decodeBlock` advances `pos` by at least 1 on success. -/
+theorem decodeBlock_consumes (d : DecodeState) :
+  ∀ d' t, decodeBlock d = some (d', t) → d'.input = d.input ∧ d'.pos > d.pos ∧ d'.pos ≤ d.input.size := by
+    intro d' t h
+    unfold decodeBlock at h
+    cases hdh : decodeHead d with
+    | none => simp [hdh] at h
+    | some res =>
+      obtain ⟨d'', m, n⟩ := res
+      simp [hdh] at h
+      obtain ⟨_, hbytes⟩ := h
+      have ⟨h1, h2, h3⟩ := decodeHead_consumes d d'' m n hdh
+      have ⟨h4, h5, h6⟩ := decodeBytes_consumes d'' n d' t hbytes
+      refine ⟨?_, ?_, ?_⟩
+      · rw [h4, h1]
+      · rw [h5]; omega
+      · rw [h1] at h6; exact h6
 
-set_option linter.unusedVariables true
+set_option linter.unusedVariables false in
+/-- Inner loop accumulating bytestring chunks until the `0xFF` terminator. -/
+def decodeBlocksLoop (acc : ByteArray) (d : DecodeState) : Option (DecodeState × ByteArray) :=
+  if d.nextUInt8 = some 0xFF then
+    .some (d.advance, acc)
+  else
+    match h : decodeBlock d with
+    | some (d', t) => decodeBlocksLoop (acc ++ t) d'
+    | none         => none
+  termination_by d.input.size - d.pos
+  decreasing_by
+    simp_wf
+    have ⟨hin, hgt, hle⟩ := decodeBlock_consumes d d' t h
+    rw [hin]
+    omega
 
 /-- Decodes an indefinite number of blocks. -/
 -- Spec B.5. D_blocks
-def decodeBlocks := decodeBlocksLoop []
+def decodeBlocks : DecodeState → Option (DecodeState × ByteArray) := decodeBlocksLoop .empty
 
-/-- Helper theorem: decodeBlocksLoop consumes bytes when recursing. -/
+/-- `decodeBlocksLoop` advances `pos` by at least 1 on success (inducted over a fuel bound). -/
 theorem decodeBlocksLoop_consumes :
-  ∀ (n : Nat) (acc s s' : List UInt8) (t : List UInt8),
-    s.length ≤ n → decodeBlocksLoop acc s = some (s', t) → s'.length < s.length := by
-  intro n
-  induction n with
-  | zero =>
-    intro acc s s' t hs h
-    cases s with
-    | nil =>
-      unfold decodeBlocksLoop at h
-      split at h <;> contradiction
-    | cons _ _ => simp at hs
-  | succ n' ih =>
-    intro acc s s' t hs h
-    match s with
-    | [] =>
-      unfold decodeBlocksLoop at h
-      split at h <;> contradiction
-    | c :: rest =>
-      unfold decodeBlocksLoop at h
-      split at h
-      · -- Case: c = 0xFF
-        rename_i s'' heq
-        simp at h
-        obtain ⟨h1, h2⟩ := h
-        subst h1
-        injection heq with heq_c heq_rest
-        subst heq_rest
-        simp
-      · -- Case: c ≠ 0xFF, must use decodeBlock
+  ∀ (n : Nat) (acc : ByteArray) (d d' : DecodeState) (t : ByteArray),
+    d.input.size - d.pos ≤ n → decodeBlocksLoop acc d = some (d', t) →
+    d'.input = d.input ∧ d'.pos > d.pos ∧ d'.pos ≤ d.input.size := by
+      intro n
+      induction n with
+      | zero =>
+        intro acc d d' t hbound h
+        unfold decodeBlocksLoop at h
         split at h
-        · -- decodeBlock succeeds and recurses
-          rename_i s'' t' hdb
-          have h_block : s''.length < (c :: rest).length := decodeBlock_consumes (c :: rest) s'' t' hdb
-          have hs'' : s''.length ≤ n' := by
-            have : (c :: rest).length = rest.length + 1 := by simp
-            rw [this] at hs
-            omega
-          have h_rec : s'.length < s''.length := ih ((List.reverse t') ++ acc) s'' s' t hs'' h
+        · -- 0xFF terminator: needs d.pos < d.input.size, contradicted by hbound
+          rename_i h_ff
+          have hposlt := DecodeState.nextUInt8_some_lt h_ff
+          simp at hposlt
           omega
-        · -- decodeBlock fails
-          contradiction
+        · split at h
+          · rename_i d'' t' hdb
+            have ⟨_, hgt, _⟩ := decodeBlock_consumes d d'' t' hdb
+            omega
+          · contradiction
+      | succ n' ih =>
+        intro acc d d' t hbound h
+        unfold decodeBlocksLoop at h
+        split at h
+        · -- 0xFF terminator branch
+          rename_i h_ff
+          have hposlt := DecodeState.nextUInt8_some_lt h_ff
+          simp at hposlt
+          simp at h
+          obtain ⟨h1, _⟩ := h
+          subst h1
+          refine ⟨rfl, ?_, ?_⟩
+          · simp
+          · show d.pos + 1 ≤ d.input.size; omega
+        · split at h
+          · -- decodeBlock succeeds, recurse
+            rename_i d'' t' hdb
+            have ⟨hbin, hbgt, hble⟩ := decodeBlock_consumes d d'' t' hdb
+            have hbound' : d''.input.size - d''.pos ≤ n' := by
+              rw [hbin]; omega
+            have ⟨hrin, hrgt, hrle⟩ := ih (acc ++ t') d'' d' t hbound' h
+            refine ⟨?_, ?_, ?_⟩
+            · rw [hrin, hbin]
+            · omega
+            · rw [hbin] at hrle; exact hrle
+          · contradiction
 
-/-- Helper theorem: decodeBlocks consumes at least one byte on success. -/
-theorem decodeBlocks_consumes : ∀ s s' t, decodeBlocks s = some (s', t) → s'.length < s.length := by
-  intro s s' t h
-  unfold decodeBlocks at h
-  exact decodeBlocksLoop_consumes s.length [] s s' t (Nat.le_refl _) h
+/-- `decodeBlocks` advances `pos` by at least 1 on success. -/
+theorem decodeBlocks_consumes :
+  ∀ d d' t, decodeBlocks d = some (d', t) →
+    d'.input = d.input ∧ d'.pos > d.pos ∧ d'.pos ≤ d.input.size := by
+      intro d d' t h
+      unfold decodeBlocks at h
+      exact decodeBlocksLoop_consumes (d.input.size - d.pos) .empty d d' t (Nat.le_refl _) h
 
-/-- Decodes a bytestring from the input list of bytes (internal, list-based). -/
-def decodeBytestringL (s : List UInt8) : Option (List UInt8 × List UInt8) :=
-  match decodeBlock s with
-  | .some (s', t) => .some (s', t)
-  | .none         => do
-      let (s', n) ← decodeIndef s
+/-- Decodes a bytestring from a `DecodeState` (internal). -/
+def decodeBytestringL (d : DecodeState) : Option (DecodeState × ByteArray) :=
+  match decodeBlock d with
+  | .some res => .some res
+  | .none     => do
+      let (d', n) ← decodeIndef d
       if n = 2
-        then decodeBlocks s'
+        then decodeBlocks d'
         else .none
 
-/-- Helper theorem: decodeBytestringL consumes at least one byte on success -/
-theorem decodeBytestringL_consumes (s : List UInt8) :
-  ∀ s' t, decodeBytestringL s = some (s', t) → s'.length < s.length := by
-  intro s' t h
-  unfold decodeBytestringL at h
-  split at h
-  · -- Case: decodeBlock succeeds
-    rename_i s'' t' hdb
-    simp at h
-    obtain ⟨h1, h2⟩ := h
-    rw [← h1]
-    exact decodeBlock_consumes s s'' t' hdb
-  · -- Case: decodeBlock fails, try decodeIndef + decodeBlocks
-    simp only [Option.bind_eq_bind, Option.bind_eq_some_iff] at h
-    obtain ⟨⟨s'', n⟩, hdi, h_rest⟩ := h
-    split at h_rest
-    · cases h_blocks : decodeBlocks s'' with
-      | none => simp [h_blocks] at h_rest
-      | some res =>
-        rcases res with ⟨ra, rb⟩
-        simp [h_blocks] at h_rest
-        obtain ⟨h_eq1, h_eq2⟩ := h_rest
-        rw [← h_eq1]
-        have h1 := decodeIndef_consumes s s'' n hdi
-        have h2 := decodeBlocks_consumes s'' ra rb h_blocks
-        omega
-    · simp at h_rest
+/-- `decodeBytestringL` advances `pos` by at least 1 on success. -/
+theorem decodeBytestringL_consumes (d : DecodeState) :
+  ∀ d' t, decodeBytestringL d = some (d', t) →
+    d'.input = d.input ∧ d'.pos > d.pos ∧ d'.pos ≤ d.input.size := by
+      intro d' t h
+      unfold decodeBytestringL at h
+      cases hdb : decodeBlock d with
+      | some pair =>
+        obtain ⟨d'', t'⟩ := pair
+        rw [hdb] at h
+        simp at h
+        obtain ⟨hd_eq, _⟩ := h
+        subst hd_eq
+        exact decodeBlock_consumes d d'' t' hdb
+      | none =>
+        rw [hdb] at h
+        simp only [Option.bind_eq_bind, Option.bind_eq_some_iff] at h
+        obtain ⟨⟨d'', n⟩, hdi, hrest⟩ := h
+        split at hrest
+        · cases hblocks : decodeBlocks d'' with
+          | none => simp [hblocks] at hrest
+          | some res =>
+            rcases res with ⟨ra, rb⟩
+            simp [hblocks] at hrest
+            obtain ⟨heqs, _⟩ := hrest
+            have ⟨h1, h2, h3⟩ := decodeIndef_consumes d d'' n hdi
+            have ⟨h4, h5, h6⟩ := decodeBlocks_consumes d'' ra rb hblocks
+            subst heqs
+            refine ⟨?_, ?_, ?_⟩
+            · rw [h4, h1]
+            · omega
+            · rw [h1] at h6; exact h6
+        · simp at hrest
 
 /-- Decodes a bytestring from the input `b`. -/
 -- Spec B.5. D_B*
 def decodeBytestring (b : ByteArray) : Option (ByteArray × ByteArray) :=
-  (decodeBytestringL b.toList).map (fun (rem, bs) => (rem.toByteArray, bs.toByteArray))
+  (decodeBytestringL { input := b, pos := 0 }).map fun (d', t) =>
+    (d'.input.extract d'.pos d'.input.size, t)
 
 /-- Decodes a "large" block, which can have a length larger than 64 bytes. -/
-def decodeLargeBlock (s : List UInt8) : Option (List UInt8 × List UInt8) := do
-  let (s', m, n) ← decodeHead s
+def decodeLargeBlock (d : DecodeState) : Option (DecodeState × ByteArray) := do
+  let (d', m, n) ← decodeHead d
   if m = 2
-    then decodeBytes n s'
+    then decodeBytes d' n
     else .none
 
-/-- Helper theorem: decodeLargeBlock consumes at least one byte on success -/
-theorem decodeLargeBlock_consumes (s : List UInt8) :
-  ∀ s' t, decodeLargeBlock s = some (s', t) → s'.length < s.length := by
-  intro s' t h
-  unfold decodeLargeBlock at h
-  simp only [Option.bind_eq_bind, Option.bind_eq_some_iff] at h
-  obtain ⟨⟨s'', m, n⟩, hdh, h⟩ := h
-  split at h
-  · have h_head := decodeHead_consumes s s'' m n hdh
-    have h_bytes := decodeBytes_consumes n s'' s' t h
-    omega
-  · simp at h
+/-- `decodeLargeBlock` advances `pos` by at least 1 on success. -/
+theorem decodeLargeBlock_consumes (d : DecodeState) :
+  ∀ d' t, decodeLargeBlock d = some (d', t) →
+    d'.input = d.input ∧ d'.pos > d.pos ∧ d'.pos ≤ d.input.size := by
+      intro d' t h
+      unfold decodeLargeBlock at h
+      cases hdh : decodeHead d with
+      | none => simp [hdh] at h
+      | some res =>
+        obtain ⟨d'', m, n⟩ := res
+        simp [hdh] at h
+        obtain ⟨_, hbytes⟩ := h
+        have ⟨h1, h2, h3⟩ := decodeHead_consumes d d'' m n hdh
+        have ⟨h4, h5, h6⟩ := decodeBytes_consumes d'' n d' t hbytes
+        refine ⟨?_, ?_, ?_⟩
+        · rw [h4, h1]
+        · rw [h5]; omega
+        · rw [h1] at h6; exact h6
 
 set_option linter.unusedVariables false in
-def decodeLargeBlocksLoop (acc : List UInt8) : List UInt8 → Option (List UInt8 × List UInt8)
-  | 0xFF :: s' => .some (s', List.reverse acc)
-  | s            => match h : decodeLargeBlock s with
-      | some (s', t) => decodeLargeBlocksLoop ((List.reverse t) ++ acc) s'
-      | none => none
-termination_by s => s.length
-decreasing_by
-  simp_wf
-  have := decodeLargeBlock_consumes s s' t h
-  omega
+def decodeLargeBlocksLoop (acc : ByteArray) (d : DecodeState) : Option (DecodeState × ByteArray) :=
+  if d.nextUInt8 = some 0xFF then
+    .some (d.advance, acc)
+  else
+    match h : decodeLargeBlock d with
+    | some (d', t) => decodeLargeBlocksLoop (acc ++ t) d'
+    | none         => none
+  termination_by d.input.size - d.pos
+  decreasing_by
+    simp_wf
+    have ⟨hin, hgt, hle⟩ := decodeLargeBlock_consumes d d' t h
+    rw [hin]
+    omega
 
 /-- Decodes a sequence of "large" blocks. -/
-def decodeLargeBlocks := decodeLargeBlocksLoop []
+def decodeLargeBlocks : DecodeState → Option (DecodeState × ByteArray) := decodeLargeBlocksLoop .empty
 
-/-- Decodes a "large" bytestring from a list of bytes (internal, list-based). -/
-def decodeLargeBytestringL (s : List UInt8) : Option (List UInt8 × List UInt8) :=
-  match decodeLargeBlock s with
-  | .some (s', t) => .some (s', t)
-  | .none         => do
-      let (s', n) ← decodeIndef s
+/-- `decodeLargeBlocksLoop` advances `pos` by at least 1 on success. -/
+theorem decodeLargeBlocksLoop_consumes :
+  ∀ (n : Nat) (acc : ByteArray) (d d' : DecodeState) (t : ByteArray),
+    d.input.size - d.pos ≤ n → decodeLargeBlocksLoop acc d = some (d', t) →
+      d'.input = d.input ∧ d'.pos > d.pos ∧ d'.pos ≤ d.input.size := by
+        intro n
+        induction n with
+        | zero =>
+          intro acc d d' t hbound h
+          unfold decodeLargeBlocksLoop at h
+          split at h
+          · rename_i h_ff
+            have hposlt := DecodeState.nextUInt8_some_lt h_ff
+            simp at hposlt
+            omega
+          · split at h
+            · rename_i d'' t' hdb
+              have ⟨_, hgt, _⟩ := decodeLargeBlock_consumes d d'' t' hdb
+              omega
+            · contradiction
+        | succ n' ih =>
+          intro acc d d' t hbound h
+          unfold decodeLargeBlocksLoop at h
+          split at h
+          · rename_i h_ff
+            have hposlt := DecodeState.nextUInt8_some_lt h_ff
+            simp at hposlt
+            simp at h
+            obtain ⟨h1, _⟩ := h
+            subst h1
+            refine ⟨rfl, ?_, ?_⟩
+            · simp
+            · show d.pos + 1 ≤ d.input.size; omega
+          · split at h
+            · rename_i d'' t' hdb
+              have ⟨hbin, hbgt, hble⟩ := decodeLargeBlock_consumes d d'' t' hdb
+              have hbound' : d''.input.size - d''.pos ≤ n' := by
+                rw [hbin]; omega
+              have ⟨hrin, hrgt, hrle⟩ := ih (acc ++ t') d'' d' t hbound' h
+              refine ⟨?_, ?_, ?_⟩
+              · rw [hrin, hbin]
+              · omega
+              · rw [hbin] at hrle; exact hrle
+            · contradiction
+
+/-- `decodeLargeBlocks` advances `pos` by at least 1 on success. -/
+theorem decodeLargeBlocks_consumes :
+  ∀ d d' t, decodeLargeBlocks d = some (d', t) →
+    d'.input = d.input ∧ d'.pos > d.pos ∧ d'.pos ≤ d.input.size := by
+      intro d d' t h
+      unfold decodeLargeBlocks at h
+      exact decodeLargeBlocksLoop_consumes (d.input.size - d.pos) .empty d d' t (Nat.le_refl _) h
+
+/-- Decodes a "large" bytestring from a `DecodeState` (internal). -/
+def decodeLargeBytestringL (d : DecodeState) : Option (DecodeState × ByteArray) :=
+  match decodeLargeBlock d with
+  | .some res => .some res
+  | .none     => do
+      let (d', n) ← decodeIndef d
       if n = 2
-        then decodeLargeBlocks s'
+        then decodeLargeBlocks d'
         else .none
 
 /-- Decodes a "large" bytestring from a `ByteArray`. -/
 def decodeLargeBytestring (b : ByteArray) : Option (ByteArray × ByteArray) :=
-  (decodeLargeBytestringL b.toList).map (fun (rem, bs) => (rem.toByteArray, bs.toByteArray))
+  (decodeLargeBytestringL { input := b, pos := 0 }).map fun (d', t) =>
+    (d'.input.extract d'.pos d'.input.size, t)
 
 /-- Reconstructs a natural number from its big endian representation. -/
 -- Spec B.6. stoi
-def stoi (bs : List UInt8) : Nat :=
-  let rec go : List UInt8 → Nat
-    | []      => 0
-    | n :: l' => 256 * go l' + n.toNat
-  go (List.reverse bs)
+def stoi (b : ByteArray) : Nat := b.foldl (fun acc x => acc * 256 + x.toNat) 0
 
-/- Decodes an integer value from a list of bytes (internal, list-based). -/
-def decodeIntL (s : List UInt8) : Option (List UInt8 × Integer) :=
-  match decodeHead s with
-  | .some (s', 0, n) => .some (s',  (Int.ofNat n)    )
-  | .some (s', 1, n) => .some (s', -(Int.ofNat n) - 1)
-  | .some (s', 6, 2) => (λ (s'', b) => (s'',              stoi b      )) <$> decodeBytestringL s'
-  | .some (s', 6, 3) => (λ (s'', b) => (s'', -(Int.ofNat (stoi b)) - 1)) <$> decodeBytestringL s'
+/-- Decodes an integer value from a `DecodeState` (internal). -/
+def decodeIntL (d : DecodeState) : Option (DecodeState × Integer) :=
+  match decodeHead d with
+  | .some (d', 0, n) => .some (d',  (Int.ofNat n)    )
+  | .some (d', 1, n) => .some (d', -(Int.ofNat n) - 1)
+  | .some (d', 6, 2) => (λ (d'', b) => (d'',              stoi b      )) <$> decodeBytestringL d'
+  | .some (d', 6, 3) => (λ (d'', b) => (d'', -(Int.ofNat (stoi b)) - 1)) <$> decodeBytestringL d'
   | _                => .none
 
-/-- Helper theorem: decodeIntL consumes at least one byte on success -/
-theorem decodeIntL_consumes (s : List UInt8) :
-  ∀ s' i, decodeIntL s = some (s', i) → s'.length < s.length := by
-  intro s' i h
-  unfold decodeIntL at h
-  split at h
-  · -- Case: decodeHead s = some (k, 0, n)
-    rename_i k n hdh
-    simp at h
-    obtain ⟨h1, h2⟩ := h
-    rw [← h1]
-    exact decodeHead_consumes s k 0 n hdh
-  · -- Case: decodeHead s = some (k, 1, n)
-    rename_i k n hdh
-    simp at h
-    obtain ⟨h1, h2⟩ := h
-    rw [← h1]
-    exact decodeHead_consumes s k 1 n hdh
-  · -- Case: decodeHead s = some (k, 6, 2), calls decodeBytestringL
-    rename_i k hdh
-    cases h_db : decodeBytestringL k with
-    | none => simp [h_db] at h
-    | some res =>
-      simp [h_db] at h
-      obtain ⟨h1, h2⟩ := h
-      have h_head := decodeHead_consumes s k 6 2 hdh
-      have h_bs := decodeBytestringL_consumes k res.1 res.2 h_db
-      rw [← h1]
-      omega
-  · -- Case: decodeHead s = some (k, 6, 3), calls decodeBytestringL
-    rename_i k hdh
-    cases h_db : decodeBytestringL k with
-    | none => simp [h_db] at h
-    | some res =>
-      simp [h_db] at h
-      obtain ⟨h1, h2⟩ := h
-      have h_head := decodeHead_consumes s k 6 3 hdh
-      have h_bs := decodeBytestringL_consumes k res.1 res.2 h_db
-      rw [← h1]
-      omega
-  · -- Case: decodeHead fails or other cases
-    simp at h
+/-- `decodeIntL` advances `pos` by at least 1 on success. -/
+theorem decodeIntL_consumes (d : DecodeState) :
+  ∀ d' i, decodeIntL d = some (d', i) →
+    d'.input = d.input ∧ d'.pos > d.pos ∧ d'.pos ≤ d.input.size := by
+      intro d' i h
+      unfold decodeIntL at h
+      split at h
+      · -- (d'', 0, n)
+        rename_i d'' n hdh
+        simp at h
+        obtain ⟨h1, _⟩ := h
+        subst h1
+        exact decodeHead_consumes d d'' 0 n hdh
+      · rename_i d'' n hdh
+        simp at h
+        obtain ⟨h1, _⟩ := h
+        subst h1
+        exact decodeHead_consumes d d'' 1 n hdh
+      · rename_i d'' hdh
+        cases hbs : decodeBytestringL d'' with
+        | none => simp [hbs] at h
+        | some res =>
+          simp [hbs] at h
+          obtain ⟨h1, _⟩ := h
+          have ⟨h2, h3, h4⟩ := decodeHead_consumes d d'' 6 2 hdh
+          have ⟨h5, h6, h7⟩ := decodeBytestringL_consumes d'' res.1 res.2 hbs
+          subst h1
+          refine ⟨?_, ?_, ?_⟩
+          · rw [h5, h2]
+          · omega
+          · rw [h2] at h7; exact h7
+      · rename_i d'' hdh
+        cases hbs : decodeBytestringL d'' with
+        | none => simp [hbs] at h
+        | some res =>
+          simp [hbs] at h
+          obtain ⟨h1, _⟩ := h
+          have ⟨h2, h3, h4⟩ := decodeHead_consumes d d'' 6 3 hdh
+          have ⟨h5, h6, h7⟩ := decodeBytestringL_consumes d'' res.1 res.2 hbs
+          subst h1
+          refine ⟨?_, ?_, ?_⟩
+          · rw [h5, h2]
+          · omega
+          · rw [h2] at h7; exact h7
+      · simp at h
 
-/- Decodes an integer value from a `ByteArray`. -/
+/-- Decodes an integer value from a `ByteArray`. -/
 --  Spec B.6. D_Z
 def decodeInt (b : ByteArray) : Option (ByteArray × Integer) :=
-  (decodeIntL b.toList).map (fun (rem, i) => (rem.toByteArray, i))
+  (decodeIntL { input := b, pos := 0 }).map fun (d', i) =>
+    (d'.input.extract d'.pos d'.input.size, i)
 
-/- Decodes a ctag from input `s`. -/
+/-- Decodes a ctag from a `DecodeState`. -/
 -- Spec B.7. D_ctag
-def decodeCtag (s : List UInt8) : Option (List UInt8 × Integer) :=
-  match decodeHead s with
-  | .some (s', 6, 102) => do
+def decodeCtag (d : DecodeState) : Option (DecodeState × Integer) :=
+  match decodeHead d with
+  | .some (d', 6, 102) => do
       -- The definite 2-element wrapper (0x82) is accepted here. The indefinite form
       -- (0x9f..0xff) that Data.hs also accepts is handled by decodeIndefConstr.
-      let (s'', m, n) ← decodeHead s'
+      let (d'', m, n) ← decodeHead d'
       if m = 4 ∧ n = 2
         then do
           -- Index is a direct Word64 (matches decodeWord64). A negative or bignum-encoded
           -- index is write-only, so reject it on decode.
-          let (s''', im, iv) ← decodeHead s''
-          if im = 0 then .some (s''', Int.ofNat iv) else .none
-        else .none
-  | .some (s', 6, i) =>      if  121 ≤ i ∧ i ≤  127 then .some (s',  i -  121     )
-                        else if 1280 ≤ i ∧ i ≤ 1400 then .some (s', (i - 1280) + 7)
+          let (d''', im, iv) ← decodeHead d''
+          if im = 0 then .some (d''', Int.ofNat iv) else .none
+        else
+          .none
+  | .some (d', 6, i) =>      if  121 ≤ i ∧ i ≤  127 then .some (d',  i -  121     )
+                        else if 1280 ≤ i ∧ i ≤ 1400 then .some (d', (i - 1280) + 7)
                         else .none
   | _ => .none
 
-/- Tries to decode a value from `s` using `f`. If fails it tries `g` with the same input. Fails if both fails. -/
-def decodeAlternative {α β : Type} (f : List UInt8 → Option (List UInt8 × α)) (g : List UInt8 → Option (List UInt8 × β)) (s : List UInt8) : Option (List UInt8 × (α ⊕ β)) :=
-  match f s with
-  | .some (s', a) => .some (s', .inl a)
-  | .none         => (λ (s', b) => (s', .inr b)) <$> g s
+/-- Tries to decode using `f`; on failure, tries `g`. -/
+def decodeAlternative {α β : Type}
+    (f : DecodeState → Option (DecodeState × α))
+    (g : DecodeState → Option (DecodeState × β))
+    (d : DecodeState) : Option (DecodeState × (α ⊕ β)) :=
+  match f d with
+  | .some (d', a) => .some (d', .inl a)
+  | .none         => (λ (d', b) => (d', .inr b)) <$> g d
 
-/-- Helper theorem: decodeAlternative consumes at least one byte on success -/
-theorem decodeAlternative_indef_head_consumes (s : List UInt8) :
-  ∀ s' r, decodeAlternative decodeIndef decodeHead s = some (s', r) → s'.length < s.length := by
-  intro s' r h
-  unfold decodeAlternative at h
-  split at h
-  · rename_i s'' n hdi
-    simp at h
-    obtain ⟨h1, h2⟩ := h
-    rw [← h1]
-    have := decodeIndef_consumes s s'' n hdi
-    omega
-  · simp [Option.map_eq_some_iff] at h
-    obtain ⟨b, hdh, hb, heq_head, heq_pair⟩ := h
-    obtain ⟨heq_s, heq_r⟩ := heq_pair
-    rw [← heq_s]
-    exact decodeHead_consumes s b hdh hb heq_head
+/-- `decodeAlternative decodeIndef decodeHead` advances `pos` by at least 1 on success. -/
+theorem decodeAlternative_indef_head_consumes (d : DecodeState) :
+  ∀ d' r, decodeAlternative decodeIndef decodeHead d = some (d', r) →
+    d'.input = d.input ∧ d'.pos > d.pos ∧ d'.pos ≤ d.input.size := by
+      intro d' r h
+      unfold decodeAlternative at h
+      split at h
+      · rename_i d'' n hdi
+        simp at h
+        obtain ⟨h1, _⟩ := h
+        subst h1
+        have ⟨h2, h3, h4⟩ := decodeIndef_consumes d d'' n hdi
+        refine ⟨h2, ?_, h4⟩
+        rw [h3]; omega
+      · cases hdh : decodeHead d with
+        | none => rw [hdh] at h; simp at h
+        | some triple =>
+          obtain ⟨d'', b, c⟩ := triple
+          rw [hdh] at h
+          simp at h
+          obtain ⟨h_eq, _⟩ := h
+          subst h_eq
+          exact decodeHead_consumes d d'' b c hdh
 
-/-- Helper theorem: decodeCtag consumes at least one byte on success -/
-theorem decodeCtag_consumes (s : List UInt8) :
-  ∀ s' i, decodeCtag s = some (s', i) → s'.length < s.length := by
-  intro s' i h
-  unfold decodeCtag at h
-  split at h
-  · -- Case: decodeHead s = some (k, 6, 102)
-    rename_i k hdh
-    simp only [Option.bind_eq_bind, Option.bind_eq_some_iff] at h
-    obtain ⟨⟨s''', m, n⟩, hdh2, h_rest⟩ := h
-    split at h_rest
-    · -- index decode succeeds (split confirms m = 4 and n = 2), index is a direct Word64
-      rename_i heq_mn
-      simp only [Option.bind_eq_some_iff] at h_rest
-      obtain ⟨⟨s4, im, iv⟩, hdh3, h_rest2⟩ := h_rest
-      split at h_rest2
-      · rename_i him
-        simp at h_rest2
-        obtain ⟨h_eq_s', h_eq_i⟩ := h_rest2
-        have h_head1 := decodeHead_consumes s k 6 102 hdh
-        have ⟨hm, hn⟩ : m = 4 ∧ n = 2 := heq_mn
-        subst hm hn
-        have h_head2 := decodeHead_consumes k s''' 4 2 hdh2
-        subst him
-        have h_head3 := decodeHead_consumes s''' s4 0 iv hdh3
-        rw [← h_eq_s']
-        omega
-      · simp at h_rest2
-    · simp at h_rest
-  · -- Case: decodeHead s = some (s'', 6, i_val) with i_val ≠ 102
-    rename_i s'' i_val hne hdh
-    split at h
-    · simp at h
-      obtain ⟨h1, h2⟩ := h
-      rw [← h1]
-      exact decodeHead_consumes s s'' 6 i_val hdh
-    · split at h
-      · simp at h
-        obtain ⟨h1, h2⟩ := h
-        rw [← h1]
-        exact decodeHead_consumes s s'' 6 i_val hdh
-      · simp at h
-  · -- Case: decodeHead fails or doesn't match pattern
-    simp at h
+/-- `decodeCtag` advances `pos` by at least 1 on success. -/
+theorem decodeCtag_consumes (d : DecodeState) :
+  ∀ df i, decodeCtag d = some (df, i) →
+    df.input = d.input ∧ df.pos > d.pos ∧ df.pos ≤ d.input.size := by
+      intro dF iF h
+      unfold decodeCtag at h
+      match hdd : decodeHead d with
+      | some (d', j, i) =>
+          if hj : j = 6
+            then
+              subst hj
+              simp [hdd, Option.bind] at h
+              if hi : i = 102 then
+                subst hi
+                match hdd' : decodeHead d' with
+                | some (d'', m, n) =>
+                    simp [hdd'] at h
+                    obtain ⟨hmn, h⟩ := h
+                    obtain ⟨hm, hn⟩ := hmn
+                    subst hm hn
+                    match hdd'' : decodeHead d'' with
+                    | some (d''', im, iv) =>
+                        simp [hdd''] at h
+                        have ⟨h1, h2, h3⟩ := decodeHead_consumes d   d'    6 102 hdd
+                        have ⟨h4, h5, h6⟩ := decodeHead_consumes d'  d''   4   2 hdd'
+                        have ⟨h7, h8, h9⟩ := decodeHead_consumes d'' d''' im  iv hdd''
+                        have ⟨h10, h11, h12⟩ := h
+                        have hf1 : dF.input = d.input      := by grind
+                        have hf2 :   dF.pos > d.pos        := by grind
+                        have hf3 :   dF.pos ≤ d.input.size := by grind
+                        grind
+                    | none =>
+                        simp [hdd''] at h
+                | none =>
+                    simp [hdd'] at h
+              else
+                simp at h
+                if hi : 121 ≤ i ∧ i ≤ 127
+                  then
+                    simp [hi] at h
+                    obtain ⟨h, _⟩ := h
+                    subst h
+                    have ⟨h1, h2, h3⟩ := decodeHead_consumes d d' 6 i hdd
+                    grind
+                  else
+                    simp [hi] at h
+                    obtain ⟨_, h, _⟩ := h
+                    subst h
+                    have ⟨h1, h2, h3⟩ := decodeHead_consumes d d' 6 i hdd
+                    grind
+          else
+            simp [hdd, hj] at h
+      | none =>
+          simp [hdd] at h
 
 -- Mutually recursive functions for decoding Data. These are defined at the top level
 -- to allow explicit signatures and mutual termination proofs.
@@ -735,93 +873,94 @@ theorem decodeCtag_consumes (s : List UInt8) :
 -- requires lemmas about byte consumption that create circular dependencies.
 mutual
   -- Main decoder loop for Data values
-  partial def decodeDataLoop (s : List UInt8) : Option (List UInt8 × Data) :=
-    match decodeAlternative decodeIndef decodeHead s with
-    | .some (_ , .inl 2     ) => Prod.map id (.B ∘ bytesToByteString) <$> decodeBytestringL s
-    | .some (s', .inl 4     ) => Prod.map id .List                    <$> decodeListIndef s'
-    | .some (s', .inl 5     ) => Prod.map id .Map                     <$> decodePairListIndef s'
+  partial def decodeDataLoop (d : DecodeState) : Option (DecodeState × Data) :=
+    match decodeAlternative decodeIndef decodeHead d with
+    | .some (_ , .inl 2     ) => Prod.map id (.B ∘ byteArrayToByteString) <$> decodeBytestringL d
+    | .some (d', .inl 4     ) => Prod.map id .List                        <$> decodeListIndef d'
+    | .some (d', .inl 5     ) => Prod.map id .Map                         <$> decodePairListIndef d'
     | .some (_ , .inr (0, _))
     | .some (_ , .inr (1, _))
     | .some (_ , .inr (6, 2))
-    | .some (_ , .inr (6, 3)) => Prod.map id .I                       <$> decodeIntL s
-    | .some (_ , .inr (2, _)) => Prod.map id (.B ∘ bytesToByteString) <$> decodeBytestringL s
-    | .some (s', .inr (4, n)) => Prod.map id .List                    <$> decodeList n s'
-    | .some (s', .inr (5, n)) => Prod.map id .Map                     <$> decodePairList n s'
-    | .some (_ , .inr (6, _)) =>                                          decodeConstr s
+    | .some (_ , .inr (6, 3)) => Prod.map id .I                           <$> decodeIntL d
+    | .some (_ , .inr (2, _)) => Prod.map id (.B ∘ byteArrayToByteString) <$> decodeBytestringL d
+    | .some (d', .inr (4, n)) => Prod.map id .List                        <$> decodeList n d'
+    | .some (d', .inr (5, n)) => Prod.map id .Map                         <$> decodePairList n d'
+    | .some (_ , .inr (6, _)) =>                                              decodeConstr d
     | _ => .none
 
   -- Decode a fixed-length list of Data values
-  partial def decodeList : Nat → List UInt8 → Option (List UInt8 × List Data)
-    | .zero  , s => .some (s, [])
-    | .succ p, s => match decodeDataLoop s with
-        | some (s', d) => match decodeList p s' with
-            | some (s'', l) => some (s'', d :: l)
-            | none => none
-        | none => none
+  partial def decodeList : Nat → DecodeState → Option (DecodeState × List Data)
+    | .zero  , d => .some (d, [])
+    | .succ p, d => do
+        let (d' , x) ← decodeDataLoop d
+        let (d'', l) ← decodeList p d'
+        return (d'', x :: l)
 
   -- Decode an indefinite-length list of Data values
-  partial def decodeListIndef : List UInt8 → Option (List UInt8 × List Data)
-    | 0xFF :: s' => .some (s', [])
-    | s            => match decodeDataLoop s with
-        | some (s', d) => match decodeListIndef s' with
-            | some (s'', l) => some (s'', d :: l)
-            | none => none
-        | none => none
+  partial def decodeListIndef (d : DecodeState) : Option (DecodeState × List Data) :=
+    match d.nextUInt8 with
+    | some 0xFF => .some (d.advance, [])
+    | _ => do
+        let (d' , x) ← decodeDataLoop d
+        let (d'', l) ← decodeListIndef d'
+        return (d'', x :: l)
 
   -- Decode a fixed-length list of Data pairs (for Map)
-  partial def decodePairList : Nat → List UInt8 → Option (List UInt8 × List (Data × Data))
-    | .zero  , s => .some (s, [])
-    | .succ p, s => match decodeDataLoop s with
-        | some (s', k) => match decodeDataLoop s' with
-            | some (s'', d) => match decodePairList p s'' with
-                | some (s''', l) => some (s''', (k, d) :: l)
-                | none => none
-            | none => none
-        | none => none
+  partial def decodePairList : Nat → DecodeState → Option (DecodeState × List (Data × Data))
+    | .zero  , d => .some (d, [])
+    | .succ p, d => do
+        let (d'  , k) ← decodeDataLoop d
+        let (d'' , v) ← decodeDataLoop d'
+        let (d''', l) ← decodePairList p d''
+        return (d''', (k, v) :: l)
 
   -- Decode an indefinite-length list of Data pairs (an indefinite-length Map, 0xbf..0xff). Spec B.7
   -- D_data decodes maps as definite-only, so this EXTENDS the decoder beyond the spec to the
   -- indefinite form Data.hs also accepts (decodeMapLenOrIndef). Decode-only, the encoder still
   -- emits only definite maps.
-  partial def decodePairListIndef : List UInt8 → Option (List UInt8 × List (Data × Data))
-    | 0xFF :: s' => .some (s', [])
-    | s          => match decodeDataLoop s with
-        | some (s', k) => match decodeDataLoop s' with
-            | some (s'', v) => match decodePairListIndef s'' with
-                | some (s''', l) => some (s''', (k, v) :: l)
-                | none => none
-            | none => none
-        | none => none
+  partial def decodePairListIndef (d : DecodeState) : Option (DecodeState × List (Data × Data)) :=
+    match d.nextUInt8 with
+    | some 0xFF => .some (d.advance, [])
+    | _ => do
+        let (d'  , k) ← decodeDataLoop d
+        let (d'' , v) ← decodeDataLoop d'
+        let (d''', l) ← decodePairListIndef d''
+        return (d''', (k, v) :: l)
 
   -- Decode a constructor whose tag-102 wrapper uses the INDEFINITE 2-element array
   -- (0x9f index args 0xff), the form Data.hs accepts via decodeListLenOrIndef. The canonical
   -- encoder never emits it, so this is decode-only leniency toward the reference implementation.
-  partial def decodeIndefConstr (s : List UInt8) : Option (List UInt8 × Data) :=
-    match decodeHead s with
-    | .some (s', 6, 102) => match decodeIndef s' with
-        | .some (s'', 4) => match decodeHead s'' with
-            | .some (s3, 0, iv) => match decodeAlternative decodeIndef decodeHead s3 with
-                | .some (s4, .inl 4     ) => match decodeListIndef s4 with
-                    | .some (0xFF :: s6, args) => .some (s6, .Constr (Int.ofNat iv) args)
-                    | _                        => .none
-                | .some (s4, .inr (4, n)) => match decodeList n s4 with
-                    | .some (0xFF :: s6, args) => .some (s6, .Constr (Int.ofNat iv) args)
-                    | _                        => .none
-                | _                       => .none
-            | _ => .none
-        | _ => .none
-    | _ => .none
+  partial def decodeIndefConstr (d : DecodeState) : Option (DecodeState × Data) := do
+    let (d', m, n) ← decodeHead d
+    guard (m = 6 ∧ n = 102)
+    let (d'', n)   ← decodeIndef d'
+    guard (n = 4)
+    let (d''', n, iv) ← decodeHead d''
+    guard (n = 0)
+    let (d4, alt) ← decodeAlternative decodeIndef decodeHead d'''
+    match alt with
+    | .inl 4 =>
+        let (di, args) ← decodeListIndef d4
+        let f          ← di.nextUInt8
+        guard (f = 0xFF)
+        return (di.advance, .Constr (Int.ofNat iv) args)
+    | .inr (4, n) =>
+        let (dd, args) ← decodeList n d4
+        let f          ← dd.nextUInt8
+        guard (f = 0xFF)
+        return (dd.advance, .Constr (Int.ofNat iv) args)
+    | _ => none
 
   -- Decode a constructor (Constr tag + list of Data values)
-  partial def decodeConstr (s : List UInt8) : Option (List UInt8 × Data) :=
-    match decodeCtag s with
-    | some (s', i) => match decodeAlternative decodeIndef decodeHead s' with
-        | some (s'', r) => match r with
-            | .inl 4      => Prod.map id (.Constr i) <$> decodeListIndef s''
-            | .inr (4, n) => Prod.map id (.Constr i) <$> decodeList n s''
+  partial def decodeConstr (d : DecodeState) : Option (DecodeState × Data) :=
+    match decodeCtag d with
+    | some (d', i) => do
+        let (d'', r) ← decodeAlternative decodeIndef decodeHead d'
+        match r with
+            | .inl 4      => Prod.map id (.Constr i) <$> decodeListIndef d''
+            | .inr (4, n) => Prod.map id (.Constr i) <$> decodeList n d''
             | _           => .none
-        | none => none
-    | none => decodeIndefConstr s
+    | none => decodeIndefConstr d
 end
 
 /- Decodes a builtin data from input `b`. -/
@@ -829,7 +968,8 @@ end
 -- Data.hs accepts: indefinite maps (decodePairListIndef) and the indefinite tag-102 constructor
 -- wrapper (decodeIndefConstr). Decode-only, the encoder is unchanged.
 def decodeData (b : ByteArray) : Option (ByteArray × Data) :=
-  (decodeDataLoop b.toList).map (fun (rem, d) => (rem.toByteArray, d))
+  (decodeDataLoop { input := b, pos := 0 }).map fun (d', x) =>
+    (d'.input.extract d'.pos d'.input.size, x)
 
 end CborInternal
 

--- a/PlutusCore/Cbor/Tests.lean
+++ b/PlutusCore/Cbor/Tests.lean
@@ -3,46 +3,52 @@ import PlutusCore.Cbor.Basic
 namespace PlutusCore.Cbor
 open PlutusCore.Cbor.CborInternal
 
+/-- Convert a String of codepoint-as-byte characters to its `ByteArray` representation.
+    Test-only helper: matches the historical convention where each Char in 0–255 stands
+    for the byte with the same value (the same convention used by the UPLC `ByteString`
+    domain wrapper). -/
+private def s2ba (s : String) : ByteArray := (Char.toUInt8 <$> s.data).toByteArray
+
 -- ==============
 -- =  Encoding  =
 -- ==============
 
-example : e₈ 7234295460216005990 = "deadbeef".toList := rfl
+example : e₈ 7234295460216005990 = "deadbeef".data.map Char.toUInt8 := by native_decide
 
-example : splitToChunks "" = [] := by native_decide
+example : splitToChunks [] = [] := by native_decide
 
-example : splitToChunks "1234567890123456789012345678901234567890123456789012345678901234" =
-  [ "1234567890123456789012345678901234567890123456789012345678901234" ] := by native_decide
+example : splitToChunks (s2ba "1234567890123456789012345678901234567890123456789012345678901234").toList =
+  [ (s2ba "1234567890123456789012345678901234567890123456789012345678901234").toList ] := by native_decide
 
-example : splitToChunks  "12345678901234567890123456789012345678901234567890123456789012345" =
-  [ "1234567890123456789012345678901234567890123456789012345678901234"
-  , "5"
+example : splitToChunks (s2ba "12345678901234567890123456789012345678901234567890123456789012345").toList =
+  [ (s2ba "1234567890123456789012345678901234567890123456789012345678901234").toList
+  , (s2ba "5").toList
   ] := by native_decide
 
-example : splitToChunks "1234567890123456789012345678901234567890123456789012345678901234123456789012345678901234567890123456789012345678901234567890123456" =
-  [ "1234567890123456789012345678901234567890123456789012345678901234"
-  , "1234567890123456789012345678901234567890123456789012345678901234"
-  , "56"
+example : splitToChunks (s2ba "1234567890123456789012345678901234567890123456789012345678901234123456789012345678901234567890123456789012345678901234567890123456").toList =
+  [ (s2ba "1234567890123456789012345678901234567890123456789012345678901234").toList
+  , (s2ba "1234567890123456789012345678901234567890123456789012345678901234").toList
+  , (s2ba "56").toList
   ] := by native_decide
 
-example : encodeBytestring "1234567890123456789012345678901234567890123456789012345678901234" =
-  .some ("\x58\x40" ++ "1234567890123456789012345678901234567890123456789012345678901234") := by native_decide
+example : encodeBytestring (s2ba "1234567890123456789012345678901234567890123456789012345678901234") =
+  .some (s2ba ("\x58\x40" ++ "1234567890123456789012345678901234567890123456789012345678901234")) := by native_decide
 
-example : encodeBytestring "12345678901234567890123456789012345678901234567890123456789012345" =
-  .some ("\x5F"
+example : encodeBytestring (s2ba "12345678901234567890123456789012345678901234567890123456789012345") =
+  .some (s2ba ("\x5F"
          ++ "\x58\x40" ++ "1234567890123456789012345678901234567890123456789012345678901234"
          ++ "\x41"     ++ "5"
-         ++ "\xFF") := by native_decide
+         ++ "\xFF")) := by native_decide
 
-example : encodeBytestring "1234567890123456789012345678901234567890123456789012345678901234123456789012345678901234567890123456789012345678901234567890123456" =
-  .some ("\x5F"
+example : encodeBytestring (s2ba "1234567890123456789012345678901234567890123456789012345678901234123456789012345678901234567890123456789012345678901234567890123456") =
+  .some (s2ba ("\x5F"
          ++ "\x58\x40" ++ "1234567890123456789012345678901234567890123456789012345678901234"
          ++ "\x58\x40" ++ "1234567890123456789012345678901234567890123456789012345678901234"
          ++ "\x42"     ++ "56"
-         ++ "\xFF") := by native_decide
+         ++ "\xFF")) := by native_decide
 
-example : encodeData (.I 12) = .some "\x0c"     := by simp [encodeData, encodeInt, encodeHead]
-example : encodeData (.I 42) = .some "\x18\x2a" := by simp [encodeData, encodeInt, encodeHead]
+example : encodeData (.I 12) = .some (s2ba "\x0c")     := by native_decide
+example : encodeData (.I 42) = .some (s2ba "\x18\x2a") := by native_decide
 
 example :
     encodeData (
@@ -50,7 +56,7 @@ example :
         .Constr 0 [.I 1284531],
         .I 1739713998000
       ]
-    ) = .some "\xd8\x79\x9f\xd8\x79\x9f\x1a\x00\x13\x99\xb3\xff\x1b\x00\x00\x01\x95\x0f\x08\xec\xb0\xff" := by native_decide
+    ) = .some (s2ba "\xd8\x79\x9f\xd8\x79\x9f\x1a\x00\x13\x99\xb3\xff\x1b\x00\x00\x01\x95\x0f\x08\xec\xb0\xff") := by native_decide
 
 example :
   encodeData (
@@ -59,17 +65,11 @@ example :
       .I 22710,
       .I 4387720097
     ]
-  ) = .some "\xd8\x79\x9f\x1a\x08\x9a\xfe\x76\x19\x58\xb6\x1b\x00\x00\x00\x01\x05\x87\x4b\xa1\xff" := by native_decide
+  ) = .some (s2ba "\xd8\x79\x9f\x1a\x08\x9a\xfe\x76\x19\x58\xb6\x1b\x00\x00\x00\x01\x05\x87\x4b\xa1\xff") := by native_decide
 
 -- ==============
 -- =  Decoding  =
 -- ==============
-
-/-- Convert a String of codepoint-as-byte characters to its `ByteArray` representation.
-    Test-only helper: matches the historical convention where each Char in 0–255 stands
-    for the byte with the same value (the same convention used by the UPLC `ByteString`
-    domain wrapper). -/
-private def s2ba (s : String) : ByteArray := (Char.toUInt8 <$> s.data).toByteArray
 
 example : d₈ ("deadbeef".data.map Char.toUInt8) = .some ([], 7234295460216005990) := by rfl
 example : d₁ ("deadbeef".data.map Char.toUInt8) = .some ("eadbeef".data.map Char.toUInt8, 100) := by rfl

--- a/PlutusCore/Cbor/Tests.lean
+++ b/PlutusCore/Cbor/Tests.lean
@@ -7,28 +7,28 @@ open PlutusCore.Cbor.CborInternal
     Test-only helper: matches the historical convention where each Char in 0–255 stands
     for the byte with the same value (the same convention used by the UPLC `ByteString`
     domain wrapper). -/
-private def s2ba (s : String) : ByteArray := (Char.toUInt8 <$> s.data).toByteArray
+private def s2ba (s : String) : ByteArray := ⟨(Char.toUInt8 <$> s.data).toArray⟩
 
 -- ==============
 -- =  Encoding  =
 -- ==============
 
-example : e₈ 7234295460216005990 = "deadbeef".data.map Char.toUInt8 := by native_decide
+example : e₈ 7234295460216005990 = "deadbeef".toUTF8 := by rfl
 
-example : splitToChunks [] = [] := by native_decide
+example : splitToChunks .empty = [] := by rfl
 
-example : splitToChunks (s2ba "1234567890123456789012345678901234567890123456789012345678901234").toList =
-  [ (s2ba "1234567890123456789012345678901234567890123456789012345678901234").toList ] := by native_decide
+example : splitToChunks (s2ba "1234567890123456789012345678901234567890123456789012345678901234") =
+  [ s2ba "1234567890123456789012345678901234567890123456789012345678901234" ] := by native_decide
 
-example : splitToChunks (s2ba "12345678901234567890123456789012345678901234567890123456789012345").toList =
-  [ (s2ba "1234567890123456789012345678901234567890123456789012345678901234").toList
-  , (s2ba "5").toList
+example : splitToChunks (s2ba "12345678901234567890123456789012345678901234567890123456789012345") =
+  [ s2ba "1234567890123456789012345678901234567890123456789012345678901234"
+  , s2ba "5"
   ] := by native_decide
 
-example : splitToChunks (s2ba "1234567890123456789012345678901234567890123456789012345678901234123456789012345678901234567890123456789012345678901234567890123456").toList =
-  [ (s2ba "1234567890123456789012345678901234567890123456789012345678901234").toList
-  , (s2ba "1234567890123456789012345678901234567890123456789012345678901234").toList
-  , (s2ba "56").toList
+example : splitToChunks (s2ba "1234567890123456789012345678901234567890123456789012345678901234123456789012345678901234567890123456789012345678901234567890123456") =
+  [ s2ba "1234567890123456789012345678901234567890123456789012345678901234"
+  , s2ba "1234567890123456789012345678901234567890123456789012345678901234"
+  , s2ba "56"
   ] := by native_decide
 
 example : encodeBytestring (s2ba "1234567890123456789012345678901234567890123456789012345678901234") =
@@ -71,8 +71,13 @@ example :
 -- =  Decoding  =
 -- ==============
 
-example : d₈ ("deadbeef".data.map Char.toUInt8) = .some ([], 7234295460216005990) := by rfl
-example : d₁ ("deadbeef".data.map Char.toUInt8) = .some ("eadbeef".data.map Char.toUInt8, 100) := by rfl
+example :
+    d₈ { input := s2ba "deadbeef", pos := 0 } =
+    .some ({ input := s2ba "deadbeef", pos := 8 }, 7234295460216005990) := by native_decide
+
+example :
+    d₁ { input := s2ba "deadbeef", pos := 0 } =
+    .some ({ input := s2ba "deadbeef", pos := 1 }, 100) := by native_decide
 
 example : decodeBytestring (s2ba ("\x58\x40" ++ "1234567890123456789012345678901234567890123456789012345678901234")) =
   .some (s2ba "", s2ba "1234567890123456789012345678901234567890123456789012345678901234") := by native_decide

--- a/PlutusCore/Cbor/Tests.lean
+++ b/PlutusCore/Cbor/Tests.lean
@@ -65,27 +65,33 @@ example :
 -- =  Decoding  =
 -- ==============
 
-example : d₈ "deadbeef".toList = .some ([], 7234295460216005990) := by rfl
-example : d₁ "deadbeef".toList = .some ("eadbeef".toList, 100)   := by rfl
+/-- Convert a String of codepoint-as-byte characters to its `ByteArray` representation.
+    Test-only helper: matches the historical convention where each Char in 0–255 stands
+    for the byte with the same value (the same convention used by the UPLC `ByteString`
+    domain wrapper). -/
+private def s2ba (s : String) : ByteArray := (Char.toUInt8 <$> s.data).toByteArray
 
-example : decodeBytestring ("\x58\x40" ++ "1234567890123456789012345678901234567890123456789012345678901234") =
-  .some ("", "1234567890123456789012345678901234567890123456789012345678901234") := by native_decide
+example : d₈ ("deadbeef".data.map Char.toUInt8) = .some ([], 7234295460216005990) := by rfl
+example : d₁ ("deadbeef".data.map Char.toUInt8) = .some ("eadbeef".data.map Char.toUInt8, 100) := by rfl
 
-example : decodeData "\x0C"     = .some ("", .I 12) := by native_decide
-example : decodeData "\x18\x2A" = .some ("", .I 42) := by native_decide
+example : decodeBytestring (s2ba ("\x58\x40" ++ "1234567890123456789012345678901234567890123456789012345678901234")) =
+  .some (s2ba "", s2ba "1234567890123456789012345678901234567890123456789012345678901234") := by native_decide
 
-example : decodeData "\xd8\x79\x9f\xd8\x79\x9f\x1a\x00\x13\x99\xb3\xff\x1b\x00\x00\x01\x95\x0f\x08\xec\xb0\xff\x34\x32"
+example : decodeData (s2ba "\x0C")     = .some (s2ba "", .I 12) := by native_decide
+example : decodeData (s2ba "\x18\x2A") = .some (s2ba "", .I 42) := by native_decide
+
+example : decodeData (s2ba "\xd8\x79\x9f\xd8\x79\x9f\x1a\x00\x13\x99\xb3\xff\x1b\x00\x00\x01\x95\x0f\x08\xec\xb0\xff\x34\x32")
     = .some (
-        "42",
+        s2ba "42",
         .Constr 0 [
           .Constr 0 [.I 1284531],
           .I 1739713998000
         ]
       ) := by native_decide
 
-example : decodeData "\xd8\x79\x9f\x1a\x08\x9a\xfe\x76\x19\x58\xb6\x1b\x00\x00\x00\x01\x05\x87\x4b\xa1\xff\x43\x62\x6f\x72\x44\x61\x74\x61"
+example : decodeData (s2ba "\xd8\x79\x9f\x1a\x08\x9a\xfe\x76\x19\x58\xb6\x1b\x00\x00\x00\x01\x05\x87\x4b\xa1\xff\x43\x62\x6f\x72\x44\x61\x74\x61")
   = .some (
-      "CborData",
+      s2ba "CborData",
       .Constr 0 [
         .I 144375414,
         .I 22710,
@@ -100,31 +106,31 @@ example : encodeData (.Constr 1 []) = .some "\xd8\x7a\x80" := by native_decide
 example : encodeData (.Constr 7 []) = .some "\xd9\x05\x00\x80" := by native_decide
 
 -- decodeData round-trips negative bignums (tag 3), not just positive (tag 2).
-example : (encodeData (.I (-(2 ^ 512 + 1)))).bind decodeData = .some ("", .I (-(2 ^ 512 + 1))) := by native_decide
+example : (encodeData (.I (-(2 ^ 512 + 1)))).bind (decodeData ∘ s2ba) = .some (s2ba "", .I (-(2 ^ 512 + 1))) := by native_decide
 
 -- Byte-anchored DECODE vector pinning the tag-1/tag-3 boundary: `-(2^64)` is the largest negative
 -- on the major-type-1 side. `-(2^64+1)` (first tag-3 negative bignum) is byte-anchored in the
 -- reference fixtures below, and would decode wrong under the old `1 - m` sign bug.
-example : decodeData "\x3b\xff\xff\xff\xff\xff\xff\xff\xff" = .some ("", .I (-(2 ^ 64))) := by native_decide
-example : (encodeData (.I (2 ^ 512))).bind decodeData = .some ("", .I (2 ^ 512)) := by native_decide
-example : (encodeData (.Constr 1 [])).bind decodeData = .some ("", .Constr 1 []) := by native_decide
+example : decodeData (s2ba "\x3b\xff\xff\xff\xff\xff\xff\xff\xff") = .some (s2ba "", .I (-(2 ^ 64))) := by native_decide
+example : (encodeData (.I (2 ^ 512))).bind (decodeData ∘ s2ba) = .some (s2ba "", .I (2 ^ 512)) := by native_decide
+example : (encodeData (.Constr 1 [])).bind (decodeData ∘ s2ba) = .some (s2ba "", .Constr 1 []) := by native_decide
 
 -- An empty ByteString is a definite 0-length string (0x40), not zero bytes, and round-trips.
 -- (The bare 0x40 and the empty-B-in-map cases are byte-anchored in the reference fixtures below.)
-example : (encodeData (.B { data := "" })).bind decodeData = .some ("", .B { data := "" }) := by native_decide
-example : (encodeData (.List [.B { data := "" }, .I 5])).bind decodeData
-  = .some ("", .List [.B { data := "" }, .I 5]) := by native_decide
+example : (encodeData (.B { data := "" })).bind (decodeData ∘ s2ba) = .some (s2ba "", .B { data := "" }) := by native_decide
+example : (encodeData (.List [.B { data := "" }, .I 5])).bind (decodeData ∘ s2ba)
+  = .some (s2ba "", .List [.B { data := "" }, .I 5]) := by native_decide
 
 -- Constructor index > 127 uses the tag-102 fallback. The index must be a direct Word64: in-range
 -- indices (128, 2^63-1, 2^64-1) are byte-anchored in the reference fixtures below. An index >= 2^64
 -- or a negative index is rejected on decode, matching the real ledger decoder (decodeWord64), even
 -- though serialiseData will emit it (write-only).
-example : (encodeData (.Constr (2 ^ 64) [.I 1])).bind decodeData = .none := by native_decide
-example : (encodeData (.Constr (-1) [])).bind decodeData = .none := by native_decide
+example : (encodeData (.Constr (2 ^ 64) [.I 1])).bind (decodeData ∘ s2ba) = .none := by native_decide
+example : (encodeData (.Constr (-1) [])).bind (decodeData ∘ s2ba) = .none := by native_decide
 
 -- Map round-trips through decodePairList (definite-length map header + key/value pairs).
-example : (encodeData (.Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [.I 4])])).bind decodeData
-  = .some ("", .Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [.I 4])]) := by native_decide
+example : (encodeData (.Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [.I 4])])).bind (decodeData ∘ s2ba)
+  = .some (s2ba "", .Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [.I 4])]) := by native_decide
 
 -- Haskell conformance for indefinite-length forms. Data.hs accepts BOTH the canonical definite
 -- encoding and an indefinite one, for maps (decodeMapLenOrIndef) and the tag-102 constructor wrapper
@@ -135,51 +141,51 @@ example : (encodeData (.Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [
 
 -- Map [(I 1, I 2)]
 example : encodeData (.Map [(.I 1, .I 2)]) = .some "\xa1\x01\x02"          := by native_decide
-example : decodeData "\xa1\x01\x02"        = .some ("", .Map [(.I 1, .I 2)]) := by native_decide
-example : decodeData "\xbf\x01\x02\xff"    = .some ("", .Map [(.I 1, .I 2)]) := by native_decide
+example : decodeData (s2ba "\xa1\x01\x02")        = .some (s2ba "", .Map [(.I 1, .I 2)]) := by native_decide
+example : decodeData (s2ba "\xbf\x01\x02\xff")    = .some (s2ba "", .Map [(.I 1, .I 2)]) := by native_decide
 -- Map []
 example : encodeData (.Map []) = .some "\xa0"        := by native_decide
-example : decodeData "\xa0"    = .some ("", .Map []) := by native_decide
-example : decodeData "\xbf\xff" = .some ("", .Map []) := by native_decide
+example : decodeData (s2ba "\xa0")    = .some (s2ba "", .Map []) := by native_decide
+example : decodeData (s2ba "\xbf\xff") = .some (s2ba "", .Map []) := by native_decide
 -- Constr 200 [] (index > 127 uses the tag-102 wrapper)
 example : encodeData (.Constr 200 [])   = .some "\xd8\x66\x82\x18\xc8\x80"     := by native_decide
-example : decodeData "\xd8\x66\x82\x18\xc8\x80"     = .some ("", .Constr 200 []) := by native_decide
-example : decodeData "\xd8\x66\x9f\x18\xc8\x80\xff" = .some ("", .Constr 200 []) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x82\x18\xc8\x80")     = .some (s2ba "", .Constr 200 []) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x18\xc8\x80\xff") = .some (s2ba "", .Constr 200 []) := by native_decide
 -- Constr 200 [I 1, I 2]
 example : encodeData (.Constr 200 [.I 1, .I 2]) = .some "\xd8\x66\x82\x18\xc8\x9f\x01\x02\xff"      := by native_decide
-example : decodeData "\xd8\x66\x82\x18\xc8\x9f\x01\x02\xff"      = .some ("", .Constr 200 [.I 1, .I 2]) := by native_decide
-example : decodeData "\xd8\x66\x9f\x18\xc8\x9f\x01\x02\xff\xff"  = .some ("", .Constr 200 [.I 1, .I 2]) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x82\x18\xc8\x9f\x01\x02\xff")      = .some (s2ba "", .Constr 200 [.I 1, .I 2]) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x18\xc8\x9f\x01\x02\xff\xff")  = .some (s2ba "", .Constr 200 [.I 1, .I 2]) := by native_decide
 
 -- Inside the indefinite wrapper the args may be definite (0x82) or indefinite (0x9f), both accepted
 -- by Data.hs and both decoding identically.
-example : decodeData "\xd8\x66\x9f\x18\xc8\x82\x01\x02\xff" = .some ("", .Constr 200 [.I 1, .I 2]) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x18\xc8\x82\x01\x02\xff") = .some (s2ba "", .Constr 200 [.I 1, .I 2]) := by native_decide
 -- The indefinite wrapper enforces the same structure Data.hs does: a Word64 index, exactly two
 -- elements (index and args), and a closing break. A negative index, a missing break, or a third
 -- element is rejected. Nesting an indefinite wrapper inside another decodes.
-example : decodeData "\xd8\x66\x9f\x20\x80\xff"         = .none := by native_decide
-example : decodeData "\xd8\x66\x9f\x18\xc8\x80"         = .none := by native_decide
-example : decodeData "\xd8\x66\x9f\x18\xc8\x80\x80\xff" = .none := by native_decide
-example : decodeData "\xd8\x66\x9f\x18\xc8\x9f\xd8\x66\x9f\x18\xc9\x80\xff\xff\xff" = .some ("", .Constr 200 [.Constr 201 []]) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x20\x80\xff")         = .none := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x18\xc8\x80")         = .none := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x18\xc8\x80\x80\xff") = .none := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x18\xc8\x9f\xd8\x66\x9f\x18\xc9\x80\xff\xff\xff") = .some (s2ba "", .Constr 200 [.Constr 201 []]) := by native_decide
 
 -- Additional Data.hs-conformance coverage. The index through the indefinite wrapper is read by a
 -- separate path (decodeIndefConstr), so anchor it at the same Word64 boundaries the definite path
 -- uses, and reject an out-of-range (bignum) index there too.
-example : decodeData "\xd8\x66\x9f\x1b\xff\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff\xff" = .some ("", .Constr (2 ^ 64 - 1) [.I 1]) := by native_decide
-example : decodeData "\xd8\x66\x9f\x1b\x80\x00\x00\x00\x00\x00\x00\x00\x80\xff" = .some ("", .Constr (2 ^ 63) []) := by native_decide
-example : decodeData "\xd8\x66\x9f\xc2\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00\x80\xff" = .none := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x1b\xff\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff\xff") = .some (s2ba "", .Constr (2 ^ 64 - 1) [.I 1]) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x1b\x80\x00\x00\x00\x00\x00\x00\x00\x80\xff") = .some (s2ba "", .Constr (2 ^ 63) []) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\xc2\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00\x80\xff") = .none := by native_decide
 -- A non-canonical small index (< 128) is valid in the wrapper too (Data.hs decodeWord64 accepts it).
-example : decodeData "\xd8\x66\x9f\x00\x80\xff" = .some ("", .Constr 0 []) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x00\x80\xff") = .some (s2ba "", .Constr 0 []) := by native_decide
 -- The "exactly two elements" rule is on the OUTER wrapper array; the args list itself is any length.
-example : decodeData "\xd8\x66\x9f\x18\xc8\x83\x01\x02\x03\xff" = .some ("", .Constr 200 [.I 1, .I 2, .I 3]) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x18\xc8\x83\x01\x02\x03\xff") = .some (s2ba "", .Constr 200 [.I 1, .I 2, .I 3]) := by native_decide
 -- Reject a third element or a missing break when the args is an INDEFINITE list (the other args branch).
-example : decodeData "\xd8\x66\x9f\x18\xc8\x9f\xff\x00\xff" = .none := by native_decide
-example : decodeData "\xd8\x66\x9f\x18\xc8\x9f\xff" = .none := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x18\xc8\x9f\xff\x00\xff") = .none := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x18\xc8\x9f\xff") = .none := by native_decide
 -- Indefinite maps: multiple pairs preserve order, a break between key and value is rejected, maps nest.
-example : decodeData "\xbf\x01\x02\x03\x04\xff" = .some ("", .Map [(.I 1, .I 2), (.I 3, .I 4)]) := by native_decide
-example : decodeData "\xbf\x01\xff" = .none := by native_decide
-example : decodeData "\xbf\x01\xbf\x02\x03\xff\xff" = .some ("", .Map [(.I 1, .Map [(.I 2, .I 3)])]) := by native_decide
+example : decodeData (s2ba "\xbf\x01\x02\x03\x04\xff") = .some (s2ba "", .Map [(.I 1, .I 2), (.I 3, .I 4)]) := by native_decide
+example : decodeData (s2ba "\xbf\x01\xff") = .none := by native_decide
+example : decodeData (s2ba "\xbf\x01\xbf\x02\x03\xff\xff") = .some (s2ba "", .Map [(.I 1, .Map [(.I 2, .I 3)])]) := by native_decide
 -- Cross-form nesting: an indefinite map inside an indefinite-wrapper constructor's args.
-example : decodeData "\xd8\x66\x9f\x18\xc8\x9f\xbf\x01\x02\xff\xff\xff" = .some ("", .Constr 200 [.Map [(.I 1, .I 2)]]) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x9f\x18\xc8\x9f\xbf\x01\x02\xff\xff\xff") = .some (s2ba "", .Constr 200 [.Map [(.I 1, .I 2)]]) := by native_decide
 
 -- Reference fixtures: golden CBOR vectors for the shapes this PR touches (empty containers, empty
 -- bytestring, negative bignums, tag-102 indices, nesting). Each pins `encodeData` to fixed bytes
@@ -188,42 +194,42 @@ example : decodeData "\xd8\x66\x9f\x18\xc8\x9f\xbf\x01\x02\xff\xff\xff" = .some 
 -- is a genuine anchor and not a self-referential round-trip.
 -- emptyList
 example : encodeData (.List []) = .some "\x80" := by native_decide
-example : decodeData "\x80" = .some ("", .List []) := by native_decide
+example : decodeData (s2ba "\x80") = .some (s2ba "", .List []) := by native_decide
 -- emptyConstr0
 example : encodeData (.Constr 0 []) = .some "\xd8\x79\x80" := by native_decide
-example : decodeData "\xd8\x79\x80" = .some ("", .Constr 0 []) := by native_decide
+example : decodeData (s2ba "\xd8\x79\x80") = .some (s2ba "", .Constr 0 []) := by native_decide
 -- emptyConstr5
 example : encodeData (.Constr 5 []) = .some "\xd8\x7e\x80" := by native_decide
-example : decodeData "\xd8\x7e\x80" = .some ("", .Constr 5 []) := by native_decide
+example : decodeData (s2ba "\xd8\x7e\x80") = .some (s2ba "", .Constr 5 []) := by native_decide
 -- emptyB
 example : encodeData (.B { data := "" }) = .some "\x40" := by native_decide
-example : decodeData "\x40" = .some ("", .B { data := "" }) := by native_decide
+example : decodeData (s2ba "\x40") = .some (s2ba "", .B { data := "" }) := by native_decide
 -- mapEmptyB
 example : encodeData (.Map [(.B { data := "" }, .I 0)]) = .some "\xa1\x40\x00" := by native_decide
-example : decodeData "\xa1\x40\x00" = .some ("", .Map [(.B { data := "" }, .I 0)]) := by native_decide
+example : decodeData (s2ba "\xa1\x40\x00") = .some (s2ba "", .Map [(.B { data := "" }, .I 0)]) := by native_decide
 -- negBignum64
 example : encodeData (.I (-(2 ^ 64 + 1))) = .some "\xc3\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00" := by native_decide
-example : decodeData "\xc3\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00" = .some ("", .I (-(2 ^ 64 + 1))) := by native_decide
+example : decodeData (s2ba "\xc3\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00") = .some (s2ba "", .I (-(2 ^ 64 + 1))) := by native_decide
 -- negBignum128
 example : encodeData (.I (-(2 ^ 128))) = .some "\xc3\x50\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" := by native_decide
-example : decodeData "\xc3\x50\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" = .some ("", .I (-(2 ^ 128))) := by native_decide
+example : decodeData (s2ba "\xc3\x50\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff") = .some (s2ba "", .I (-(2 ^ 128))) := by native_decide
 -- constr128
 example : encodeData (.Constr 128 []) = .some "\xd8\x66\x82\x18\x80\x80" := by native_decide
-example : decodeData "\xd8\x66\x82\x18\x80\x80" = .some ("", .Constr 128 []) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x82\x18\x80\x80") = .some (s2ba "", .Constr 128 []) := by native_decide
 -- constrBig (2^63-1)
 example : encodeData (.Constr (2 ^ 63 - 1) [.I 1]) = .some "\xd8\x66\x82\x1b\x7f\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff" := by native_decide
-example : decodeData "\xd8\x66\x82\x1b\x7f\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff" = .some ("", .Constr (2 ^ 63 - 1) [.I 1]) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x82\x1b\x7f\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff") = .some (s2ba "", .Constr (2 ^ 63 - 1) [.I 1]) := by native_decide
 -- constrMax (2^64-1, the largest in-range Word64 index)
 example : encodeData (.Constr (2 ^ 64 - 1) [.I 1]) = .some "\xd8\x66\x82\x1b\xff\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff" := by native_decide
-example : decodeData "\xd8\x66\x82\x1b\xff\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff" = .some ("", .Constr (2 ^ 64 - 1) [.I 1]) := by native_decide
+example : decodeData (s2ba "\xd8\x66\x82\x1b\xff\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff") = .some (s2ba "", .Constr (2 ^ 64 - 1) [.I 1]) := by native_decide
 -- nested
 example : encodeData (.Constr 0 [.List [], .I 5]) = .some "\xd8\x79\x9f\x80\x05\xff" := by native_decide
-example : decodeData "\xd8\x79\x9f\x80\x05\xff" = .some ("", .Constr 0 [.List [], .I 5]) := by native_decide
+example : decodeData (s2ba "\xd8\x79\x9f\x80\x05\xff") = .some (s2ba "", .Constr 0 [.List [], .I 5]) := by native_decide
 -- mapKV
 example : encodeData (.Map [(.I 0, .I 1)]) = .some "\xa1\x00\x01" := by native_decide
-example : decodeData "\xa1\x00\x01" = .some ("", .Map [(.I 0, .I 1)]) := by native_decide
+example : decodeData (s2ba "\xa1\x00\x01") = .some (s2ba "", .Map [(.I 0, .I 1)]) := by native_decide
 -- listII
 example : encodeData (.List [.I 1, .I 2]) = .some "\x9f\x01\x02\xff" := by native_decide
-example : decodeData "\x9f\x01\x02\xff" = .some ("", .List [.I 1, .I 2]) := by native_decide
+example : decodeData (s2ba "\x9f\x01\x02\xff") = .some (s2ba "", .List [.I 1, .I 2]) := by native_decide
 
 end PlutusCore.Cbor

--- a/PlutusCore/Cbor/Tests.lean
+++ b/PlutusCore/Cbor/Tests.lean
@@ -67,6 +67,15 @@ example :
     ]
   ) = .some (s2ba "\xd8\x79\x9f\x1a\x08\x9a\xfe\x76\x19\x58\xb6\x1b\x00\x00\x00\x01\x05\x87\x4b\xa1\xff") := by native_decide
 
+-- Bignum encoding (magnitude ≥ 2^64) goes through `itos`, which must be big-endian (Spec B.6).
+example : itos 258 = s2ba "\x01\x02" := by native_decide
+-- Positive bignum: CBOR tag 2 (0xc2), then a 9-byte bytestring 01 00…00 for 2^64.
+example : encodeData (.I 18446744073709551616) =
+  .some (s2ba "\xc2\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00") := by native_decide
+-- Negative bignum: CBOR tag 3 (0xc3); the encoded magnitude is -n-1 = 2^64.
+example : encodeData (.I (-18446744073709551617)) =
+  .some (s2ba "\xc3\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00") := by native_decide
+
 -- ==============
 -- =  Decoding  =
 -- ==============
@@ -107,35 +116,35 @@ example : decodeData (s2ba "\xd8\x79\x9f\x1a\x08\x9a\xfe\x76\x19\x58\xb6\x1b\x00
 -- Empty collections encode as a DEFINITE empty array (0x80), matching the on-chain
 -- serialiseData builtin (aiken/cbor.serialise), not an indefinite 0x9f..0xff.
 -- (The List [], Constr 0, and nested cases are byte-anchored in the reference fixtures below.)
-example : encodeData (.Constr 1 []) = .some "\xd8\x7a\x80" := by native_decide
-example : encodeData (.Constr 7 []) = .some "\xd9\x05\x00\x80" := by native_decide
+example : encodeData (.Constr 1 []) = .some ⟨#[0xd8, 0x7a, 0x80]⟩ := by native_decide
+example : encodeData (.Constr 7 []) = .some ⟨#[0xd9, 0x05, 0x00, 0x80]⟩ := by native_decide
 
 -- decodeData round-trips negative bignums (tag 3), not just positive (tag 2).
-example : (encodeData (.I (-(2 ^ 512 + 1)))).bind (decodeData ∘ s2ba) = .some (s2ba "", .I (-(2 ^ 512 + 1))) := by native_decide
+example : (encodeData (.I (-(2 ^ 512 + 1)))).bind decodeData = .some (.empty, .I (-(2 ^ 512 + 1))) := by native_decide
 
 -- Byte-anchored DECODE vector pinning the tag-1/tag-3 boundary: `-(2^64)` is the largest negative
 -- on the major-type-1 side. `-(2^64+1)` (first tag-3 negative bignum) is byte-anchored in the
 -- reference fixtures below, and would decode wrong under the old `1 - m` sign bug.
-example : decodeData (s2ba "\x3b\xff\xff\xff\xff\xff\xff\xff\xff") = .some (s2ba "", .I (-(2 ^ 64))) := by native_decide
-example : (encodeData (.I (2 ^ 512))).bind (decodeData ∘ s2ba) = .some (s2ba "", .I (2 ^ 512)) := by native_decide
-example : (encodeData (.Constr 1 [])).bind (decodeData ∘ s2ba) = .some (s2ba "", .Constr 1 []) := by native_decide
+example : decodeData ⟨#[0x3b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]⟩ = .some (.empty, .I (-(2 ^ 64))) := by native_decide
+example : (encodeData (.I (2 ^ 512))).bind decodeData = .some (.empty, .I (2 ^ 512)) := by native_decide
+example : (encodeData (.Constr 1 [])).bind decodeData = .some (.empty, .Constr 1 []) := by native_decide
 
 -- An empty ByteString is a definite 0-length string (0x40), not zero bytes, and round-trips.
 -- (The bare 0x40 and the empty-B-in-map cases are byte-anchored in the reference fixtures below.)
-example : (encodeData (.B { data := "" })).bind (decodeData ∘ s2ba) = .some (s2ba "", .B { data := "" }) := by native_decide
-example : (encodeData (.List [.B { data := "" }, .I 5])).bind (decodeData ∘ s2ba)
-  = .some (s2ba "", .List [.B { data := "" }, .I 5]) := by native_decide
+example : (encodeData (.B { data := "" })).bind decodeData = .some (.empty, .B { data := "" }) := by native_decide
+example : (encodeData (.List [.B { data := "" }, .I 5])).bind decodeData
+  = .some (.empty, .List [.B { data := "" }, .I 5]) := by native_decide
 
 -- Constructor index > 127 uses the tag-102 fallback. The index must be a direct Word64: in-range
 -- indices (128, 2^63-1, 2^64-1) are byte-anchored in the reference fixtures below. An index >= 2^64
 -- or a negative index is rejected on decode, matching the real ledger decoder (decodeWord64), even
 -- though serialiseData will emit it (write-only).
-example : (encodeData (.Constr (2 ^ 64) [.I 1])).bind (decodeData ∘ s2ba) = .none := by native_decide
-example : (encodeData (.Constr (-1) [])).bind (decodeData ∘ s2ba) = .none := by native_decide
+example : (encodeData (.Constr (2 ^ 64) [.I 1])).bind decodeData = .none := by native_decide
+example : (encodeData (.Constr (-1) [])).bind decodeData = .none := by native_decide
 
 -- Map round-trips through decodePairList (definite-length map header + key/value pairs).
-example : (encodeData (.Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [.I 4])])).bind (decodeData ∘ s2ba)
-  = .some (s2ba "", .Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [.I 4])]) := by native_decide
+example : (encodeData (.Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [.I 4])])).bind decodeData
+  = .some (.empty, .Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [.I 4])]) := by native_decide
 
 -- Haskell conformance for indefinite-length forms. Data.hs accepts BOTH the canonical definite
 -- encoding and an indefinite one, for maps (decodeMapLenOrIndef) and the tag-102 constructor wrapper
@@ -145,19 +154,19 @@ example : (encodeData (.Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [
 -- encoding, not merely to acceptance.
 
 -- Map [(I 1, I 2)]
-example : encodeData (.Map [(.I 1, .I 2)]) = .some "\xa1\x01\x02"          := by native_decide
+example : encodeData (.Map [(.I 1, .I 2)]) = .some (s2ba "\xa1\x01\x02")          := by native_decide
 example : decodeData (s2ba "\xa1\x01\x02")        = .some (s2ba "", .Map [(.I 1, .I 2)]) := by native_decide
 example : decodeData (s2ba "\xbf\x01\x02\xff")    = .some (s2ba "", .Map [(.I 1, .I 2)]) := by native_decide
 -- Map []
-example : encodeData (.Map []) = .some "\xa0"        := by native_decide
+example : encodeData (.Map []) = .some (s2ba "\xa0")        := by native_decide
 example : decodeData (s2ba "\xa0")    = .some (s2ba "", .Map []) := by native_decide
 example : decodeData (s2ba "\xbf\xff") = .some (s2ba "", .Map []) := by native_decide
 -- Constr 200 [] (index > 127 uses the tag-102 wrapper)
-example : encodeData (.Constr 200 [])   = .some "\xd8\x66\x82\x18\xc8\x80"     := by native_decide
+example : encodeData (.Constr 200 [])   = .some (s2ba "\xd8\x66\x82\x18\xc8\x80")     := by native_decide
 example : decodeData (s2ba "\xd8\x66\x82\x18\xc8\x80")     = .some (s2ba "", .Constr 200 []) := by native_decide
 example : decodeData (s2ba "\xd8\x66\x9f\x18\xc8\x80\xff") = .some (s2ba "", .Constr 200 []) := by native_decide
 -- Constr 200 [I 1, I 2]
-example : encodeData (.Constr 200 [.I 1, .I 2]) = .some "\xd8\x66\x82\x18\xc8\x9f\x01\x02\xff"      := by native_decide
+example : encodeData (.Constr 200 [.I 1, .I 2]) = .some (s2ba "\xd8\x66\x82\x18\xc8\x9f\x01\x02\xff")      := by native_decide
 example : decodeData (s2ba "\xd8\x66\x82\x18\xc8\x9f\x01\x02\xff")      = .some (s2ba "", .Constr 200 [.I 1, .I 2]) := by native_decide
 example : decodeData (s2ba "\xd8\x66\x9f\x18\xc8\x9f\x01\x02\xff\xff")  = .some (s2ba "", .Constr 200 [.I 1, .I 2]) := by native_decide
 
@@ -198,43 +207,47 @@ example : decodeData (s2ba "\xd8\x66\x9f\x18\xc8\x9f\xbf\x01\x02\xff\xff\xff") =
 -- reference (`Data.hs` / cborg / RFC 8949), hand-verifiable byte by byte, so the encode direction
 -- is a genuine anchor and not a self-referential round-trip.
 -- emptyList
-example : encodeData (.List []) = .some "\x80" := by native_decide
-example : decodeData (s2ba "\x80") = .some (s2ba "", .List []) := by native_decide
+example : encodeData (.List []) = .some ⟨#[0x80]⟩ := by native_decide
+example : decodeData ⟨#[0x80]⟩ = .some (.empty, .List []) := by native_decide
 -- emptyConstr0
-example : encodeData (.Constr 0 []) = .some "\xd8\x79\x80" := by native_decide
-example : decodeData (s2ba "\xd8\x79\x80") = .some (s2ba "", .Constr 0 []) := by native_decide
+example : encodeData (.Constr 0 []) = .some ⟨#[0xd8, 0x79, 0x80]⟩ := by native_decide
+example : decodeData ⟨#[0xd8, 0x79, 0x80]⟩ = .some (.empty, .Constr 0 []) := by native_decide
 -- emptyConstr5
-example : encodeData (.Constr 5 []) = .some "\xd8\x7e\x80" := by native_decide
-example : decodeData (s2ba "\xd8\x7e\x80") = .some (s2ba "", .Constr 5 []) := by native_decide
+example : encodeData (.Constr 5 []) = .some ⟨#[0xd8, 0x7e, 0x80]⟩ := by native_decide
+example : decodeData ⟨#[0xd8, 0x7e, 0x80]⟩ = .some (.empty, .Constr 5 []) := by native_decide
 -- emptyB
-example : encodeData (.B { data := "" }) = .some "\x40" := by native_decide
-example : decodeData (s2ba "\x40") = .some (s2ba "", .B { data := "" }) := by native_decide
+example : encodeData (.B { data := "" }) = .some ⟨#[0x40]⟩ := by native_decide
+example : decodeData ⟨#[0x40]⟩ = .some (.empty, .B { data := "" }) := by native_decide
 -- mapEmptyB
-example : encodeData (.Map [(.B { data := "" }, .I 0)]) = .some "\xa1\x40\x00" := by native_decide
-example : decodeData (s2ba "\xa1\x40\x00") = .some (s2ba "", .Map [(.B { data := "" }, .I 0)]) := by native_decide
+example : encodeData (.Map [(.B { data := "" }, .I 0)]) = .some ⟨#[0xa1, 0x40, 0x00]⟩ := by native_decide
+example : decodeData ⟨#[0xa1, 0x40, 0x00]⟩ = .some (.empty, .Map [(.B { data := "" }, .I 0)]) := by native_decide
 -- negBignum64
-example : encodeData (.I (-(2 ^ 64 + 1))) = .some "\xc3\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00" := by native_decide
-example : decodeData (s2ba "\xc3\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00") = .some (s2ba "", .I (-(2 ^ 64 + 1))) := by native_decide
+example : encodeData (.I (-(2 ^ 64 + 1))) = .some ⟨#[0xc3, 0x49, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]⟩ := by native_decide
+example : decodeData ⟨#[0xc3, 0x49, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]⟩ = .some (.empty, .I (-(2 ^ 64 + 1))) := by native_decide
 -- negBignum128
-example : encodeData (.I (-(2 ^ 128))) = .some "\xc3\x50\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" := by native_decide
-example : decodeData (s2ba "\xc3\x50\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff") = .some (s2ba "", .I (-(2 ^ 128))) := by native_decide
+example : encodeData (.I (-(2 ^ 128))) = .some ⟨#[0xc3, 0x50, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]⟩ := by native_decide
+example : decodeData ⟨#[0xc3, 0x50, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]⟩ = .some (.empty, .I (-(2 ^ 128))) := by native_decide
 -- constr128
-example : encodeData (.Constr 128 []) = .some "\xd8\x66\x82\x18\x80\x80" := by native_decide
-example : decodeData (s2ba "\xd8\x66\x82\x18\x80\x80") = .some (s2ba "", .Constr 128 []) := by native_decide
+example : encodeData (.Constr 128 []) = .some ⟨#[0xd8, 0x66, 0x82, 0x18, 0x80, 0x80]⟩ := by native_decide
+example : decodeData ⟨#[0xd8, 0x66, 0x82, 0x18, 0x80, 0x80]⟩ = .some (.empty, .Constr 128 []) := by native_decide
 -- constrBig (2^63-1)
-example : encodeData (.Constr (2 ^ 63 - 1) [.I 1]) = .some "\xd8\x66\x82\x1b\x7f\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff" := by native_decide
-example : decodeData (s2ba "\xd8\x66\x82\x1b\x7f\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff") = .some (s2ba "", .Constr (2 ^ 63 - 1) [.I 1]) := by native_decide
+example : encodeData (.Constr (2 ^ 63 - 1) [.I 1]) = .some ⟨#[0xd8, 0x66, 0x82, 0x1b, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x9f, 0x01, 0xff]⟩ := by native_decide
+example : decodeData ⟨#[0xd8, 0x66, 0x82, 0x1b, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x9f, 0x01, 0xff]⟩ = .some (.empty, .Constr (2 ^ 63 - 1) [.I 1]) := by native_decide
 -- constrMax (2^64-1, the largest in-range Word64 index)
-example : encodeData (.Constr (2 ^ 64 - 1) [.I 1]) = .some "\xd8\x66\x82\x1b\xff\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff" := by native_decide
-example : decodeData (s2ba "\xd8\x66\x82\x1b\xff\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff") = .some (s2ba "", .Constr (2 ^ 64 - 1) [.I 1]) := by native_decide
+example : encodeData (.Constr (2 ^ 64 - 1) [.I 1]) = .some ⟨#[0xd8, 0x66, 0x82, 0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x9f, 0x01, 0xff]⟩ := by native_decide
+example : decodeData ⟨#[0xd8, 0x66, 0x82, 0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x9f, 0x01, 0xff]⟩ = .some (.empty, .Constr (2 ^ 64 - 1) [.I 1]) := by native_decide
 -- nested
-example : encodeData (.Constr 0 [.List [], .I 5]) = .some "\xd8\x79\x9f\x80\x05\xff" := by native_decide
-example : decodeData (s2ba "\xd8\x79\x9f\x80\x05\xff") = .some (s2ba "", .Constr 0 [.List [], .I 5]) := by native_decide
+example : encodeData (.Constr 0 [.List [], .I 5]) = .some ⟨#[0xd8, 0x79, 0x9f, 0x80, 0x05, 0xff]⟩ := by native_decide
+example : decodeData ⟨#[0xd8, 0x79, 0x9f, 0x80, 0x05, 0xff]⟩ = .some (.empty, .Constr 0 [.List [], .I 5]) := by native_decide
 -- mapKV
-example : encodeData (.Map [(.I 0, .I 1)]) = .some "\xa1\x00\x01" := by native_decide
-example : decodeData (s2ba "\xa1\x00\x01") = .some (s2ba "", .Map [(.I 0, .I 1)]) := by native_decide
+example : encodeData (.Map [(.I 0, .I 1)]) = .some ⟨#[0xa1, 0x00, 0x01]⟩ := by native_decide
+example : decodeData ⟨#[0xa1, 0x00, 0x01]⟩ = .some (.empty, .Map [(.I 0, .I 1)]) := by native_decide
 -- listII
-example : encodeData (.List [.I 1, .I 2]) = .some "\x9f\x01\x02\xff" := by native_decide
-example : decodeData (s2ba "\x9f\x01\x02\xff") = .some (s2ba "", .List [.I 1, .I 2]) := by native_decide
+example : encodeData (.List [.I 1, .I 2]) = .some ⟨#[0x9f, 0x01, 0x02, 0xff]⟩ := by native_decide
+example : decodeData ⟨#[0x9f, 0x01, 0x02, 0xff]⟩ = .some (.empty, .List [.I 1, .I 2]) := by native_decide
+
+-- Bignum decode: reads the big-endian bytestring back to 2^64 (round-trips with encoding above).
+example : decodeData (s2ba "\xc2\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00") =
+  .some (s2ba "", .I 18446744073709551616) := by native_decide
 
 end PlutusCore.Cbor

--- a/PlutusCore/UPLC/BuiltinFunctions/Data.lean
+++ b/PlutusCore/UPLC/BuiltinFunctions/Data.lean
@@ -30,6 +30,7 @@ namespace PLC
   open PlutusCore.Cbor
   export PlutusCore.Cbor (
     encodeData
+    byteArrayToByteString
   )
 end PLC
 
@@ -160,7 +161,7 @@ def mkNilPairData (Vs : List CekValue) : Option CekValue :=
 -- Define serializeData
 def serializeData (Vs : List CekValue) : Option CekValue :=
   match Vs with
-  | [CekValue.VCon (Const.Data d)] => (CekValue.VCon ∘ Const.ByteString ∘ ByteString.mk) <$> PLC.encodeData d
+  | [CekValue.VCon (Const.Data d)] => (CekValue.VCon ∘ Const.ByteString ∘ PLC.byteArrayToByteString) <$> PLC.encodeData d
   | _                              => none
 
 end PlutusCore.UPLC.BuiltinFunctions.Data

--- a/PlutusCore/UPLC/FlatEncoding/Basic.lean
+++ b/PlutusCore/UPLC/FlatEncoding/Basic.lean
@@ -48,10 +48,10 @@ def DecodeState.absBit (d : DecodeState) : Nat := 8 * d.bytePos + d.bitPos.val
     `bitSequenceFromBytes` exactly. -/
 def DecodeState.nextBit (d : DecodeState) (skip : Nat := 0) : Option Bool :=
   if skip = 0 then
-    d.input[d.bytePos]?.map (fun b => b.toBitVec.getMsbD d.bitPos.val)
+    ((BitVec.getMsbD · d.bitPos.val) ∘ UInt8.toBitVec) <$> d.input[d.bytePos]?
   else
     let total := d.bitPos.val + skip
-    d.input[d.bytePos + total / 8]?.map (fun b => b.toBitVec.getMsbD (total % 8))
+    ((BitVec.getMsbD · (total % 8)) ∘ UInt8.toBitVec)  <$> d.input[d.bytePos + total / 8]?
 
 @[simp] theorem DecodeState.advance_input (d : DecodeState) (n : Nat) :
     (d.advance n).input = d.input := rfl

--- a/PlutusCore/UPLC/FlatEncoding/Basic.lean
+++ b/PlutusCore/UPLC/FlatEncoding/Basic.lean
@@ -331,7 +331,7 @@ def varName (debruijn : Nat) : String := s!"dbi_{debruijn}"
 /- Decodes a DeBruijn index.
    Flat encodes 1-based relative indices (index 0 is invalid); `Term.Var`
    uses 0-based indices (0 = innermost binder), so we subtract 1. -/
-def decodeVar (nextDebruijn : Nat) (d : DecodeState) : Option (DecodeState × Nat) := do
+def decodeVar (d : DecodeState) : Option (DecodeState × Nat) := do
   let (d', n) ← decodeNat d
   let _       ← Option.filter (λ () => n > 0) (.some ())
   .some (d', n - 1)
@@ -340,7 +340,7 @@ def decodeVar (nextDebruijn : Nat) (d : DecodeState) : Option (DecodeState × Na
 partial def decodeTerm (v : Version) (nextDeBruijn : Nat) (d : DecodeState) : Option (DecodeState × Term) := do
   let (d, op) ← decodeFixedNat 4 d
   match op with
-  | 0 => Prod.map id .Var                          <$> decodeVar nextDeBruijn d
+  | 0 => Prod.map id .Var                          <$> decodeVar d
   | 1 => Prod.map id .Delay                        <$> decodeTerm v nextDeBruijn d
   | 2 => Prod.map id (.Lam (varName nextDeBruijn)) <$> decodeTerm v (nextDeBruijn + 1) d
   | 3 => do

--- a/PlutusCore/UPLC/FlatEncoding/Basic.lean
+++ b/PlutusCore/UPLC/FlatEncoding/Basic.lean
@@ -21,92 +21,136 @@ open PlutusCore.UPLC.Term
 
 namespace Internal
 
-/- Removes padding from the bit sequence. -/
+/-- A bit-level cursor into a `ByteArray`. `bytePos` indexes the current byte, and
+    `bitPos : Fin 8` is the bit within that byte (MSB-first). The split layout avoids
+    mod/div on every bit read — `nextBit` (the default no-skip case) does pure indexing. -/
+structure DecodeState where
+  input   : ByteArray
+  bytePos : Nat
+  bitPos  : Fin 8
+deriving DecidableEq
+
+/-- Advance the cursor by `n` bits, re-normalising into (bytePos, bitPos). -/
+def DecodeState.advance (d : DecodeState) (n : Nat := 1) : DecodeState :=
+  let total := d.bitPos.val + n
+  { d with
+    bytePos := d.bytePos + total / 8,
+    bitPos  := ⟨total % 8, Nat.mod_lt _ (by decide)⟩ }
+
+/-- Total number of bits in the input buffer. -/
+def DecodeState.totalBits (d : DecodeState) : Nat := 8 * d.input.size
+
+/-- Total bit offset from the start of the input. -/
+def DecodeState.absBit (d : DecodeState) : Nat := 8 * d.bytePos + d.bitPos.val
+
+/-- Read the bit at offset `bitPos + skip` (default `skip = 0` does no mod/div).
+    Uses `BitVec.getMsbD` so the bit order matches the legacy MSB-first
+    `bitSequenceFromBytes` exactly. -/
+def DecodeState.nextBit (d : DecodeState) (skip : Nat := 0) : Option Bool :=
+  if skip = 0 then
+    d.input[d.bytePos]?.map (fun b => b.toBitVec.getMsbD d.bitPos.val)
+  else
+    let total := d.bitPos.val + skip
+    d.input[d.bytePos + total / 8]?.map (fun b => b.toBitVec.getMsbD (total % 8))
+
+@[simp] theorem DecodeState.advance_input (d : DecodeState) (n : Nat) :
+    (d.advance n).input = d.input := rfl
+
+/-- Helper for `unpad`: read `k` bits starting at offset `offset`, expecting
+    the pattern `0...01` (k-1 zeros then a one). Returns `some ()` on match. -/
+private def readPadAt (d : DecodeState) (offset : Nat) : Nat → Option Unit
+  | 0     => .none
+  | 1     => do
+      let b ← d.nextBit offset
+      if b then .some () else .none
+  | k + 2 => do
+      let b ← d.nextBit offset
+      if b then .none else readPadAt d (offset + 1) (k + 1)
+
+/- Removes padding from the bit sequence (advances `d` to the next byte boundary). -/
 -- Spec C.1.1. Padding
-def unpad : List Bool → Option (List Bool)
-  | false :: false :: false :: false :: false :: false :: false :: true :: s => .some s
-  | false :: false :: false :: false :: false :: false :: true          :: s => .some s
-  | false :: false :: false :: false :: false :: true                   :: s => .some s
-  | false :: false :: false :: false :: true                            :: s => .some s
-  | false :: false :: false :: true                                     :: s => .some s
-  | false :: false :: true                                              :: s => .some s
-  | false :: true                                                       :: s => .some s
-  | true                                                                :: s => .some s
-  | _                                                                        => .none
+def unpad (d : DecodeState) : Option DecodeState :=
+  let n : Nat := 8 - d.bitPos.val
+  match readPadAt d 0 n with
+  | .some () => .some (d.advance n)
+  | .none    => .none
 
 /- Decodes a fixed with natural number. -/
 -- Spec C.2.1. Fixed-width natural numbers
-def decodeFixedNat : Nat → List Bool → Option (List Bool × Nat)
-  | .zero  ,          s => .some (s, 0)
-  | .succ p, false :: s => decodeFixedNat p s
-  | .succ p, true  :: s => Prod.map id (2 ^ p + ·) <$> decodeFixedNat p s
-  | _      , _          => .none
+def decodeFixedNat : Nat → DecodeState → Option (DecodeState × Nat)
+  | 0    , d => .some (d, 0)
+  | p + 1, d => do
+      let b       ← d.nextBit
+      let (d', n) ← decodeFixedNat p d.advance
+      .some (d', if b then 2 ^ p + n else n)
 
 /- Decodes a list. -/
 -- Spec C.2.2. Lists
-partial def decodeList {α : Type} (f : List Bool → Option (List Bool × α)) : List Bool -> Option (List Bool × List α)
-  | false :: s => .some (s, [])
-  | true  :: s => do
-      let (s' , x) ← f s
-      let (s'', l) ← decodeList f s'
-      .some (s'', x :: l)
-  | _ => .none
+partial def decodeList {α : Type} (f : DecodeState → Option (DecodeState × α))
+  (d : DecodeState) : Option (DecodeState × List α) := do
+    let b ← d.nextBit
+    if b then
+      let (d' , x) ← f d.advance
+      let (d'', l) ← decodeList f d'
+      .some (d'', x :: l)
+    else
+      .some (d.advance, [])
 
 /- Decodes a variable width natural number. -/
 -- Spec C.2.3. Natural numbers
-def decodeNat (s : List Bool) : Option (List Bool × Nat) := do
-  let (s' , ks) ← decodeList (decodeFixedNat 7) s
-  let (s'', l)  ← decodeFixedNat 7 s'
+def decodeNat (d : DecodeState) : Option (DecodeState × Nat) := do
+  let (d' , ks) ← decodeList (decodeFixedNat 7) d
+  let (d'', l)  ← decodeFixedNat 7 d'
   let series    := List.mapIdx (λ i ki => ki * 2 ^ (7 * i)) (ks ++ [l])
-  .some (s'', List.sum series)
+  .some (d'', List.sum series)
 
 /- Decodes an integer. -/
 -- Spec C.2.4. Integers
-def decodeInt (s : List Bool) : Option (List Bool × Integer) := do
-  let (s', n) ← decodeNat s
+def decodeInt (d : DecodeState) : Option (DecodeState × Integer) := do
+  let (d', n) ← decodeNat d
   if n % 2 = 0
-    then .some (s',              n      / 2)
-    else .some (s', - (Int.ofNat n + 1) / 2)
+    then .some (d',              n      / 2)
+    else .some (d', - (Int.ofNat n + 1) / 2)
 
 -- Spec C.2.5. Bytestrings
 -- D_C^(n)
-def decodeChunk : Nat → List Bool → List UInt8 → Option (List Bool × List UInt8)
-  | .zero  , s, l => .some (s, List.reverse l)
-  | .succ p, s, l => do
-      let (s', x) ← decodeFixedNat 8 s
-      decodeChunk p s' (x.toUInt8 :: l)
+def decodeChunk : Nat → DecodeState → List UInt8 → Option (DecodeState × List UInt8)
+  | .zero  , d, l => .some (d, List.reverse l)
+  | .succ p, d, l => do
+      let (d', x) ← decodeFixedNat 8 d
+      decodeChunk p d' (x.toUInt8 :: l)
 
 -- D_C
-def decodeChunks (s : List Bool) : Option (List Bool × List UInt8) := do
-  let (s', n) ← decodeFixedNat 8 s
-  decodeChunk n s' []
+def decodeChunks (d : DecodeState) : Option (DecodeState × List UInt8) := do
+  let (d', n) ← decodeFixedNat 8 d
+  decodeChunk n d' []
 
 -- D_C*
-partial def decodeCStar (s : List Bool) : Option (List Bool × List UInt8) := do
-  let (s', x) ← decodeChunks s
+partial def decodeCStar (d : DecodeState) : Option (DecodeState × List UInt8) := do
+  let (d', x) ← decodeChunks d
   match x with
-  | [] => .some (s', [])
+  | [] => .some (d', [])
   | x  =>
-      let (s'', l) ← decodeCStar s'
-      .some (s'', x ++ l)
+      let (d'', l) ← decodeCStar d'
+      .some (d'', x ++ l)
 
 /- Decodes a Bytestring. -/
-def decodeBytestring (s : List Bool) : Option (List Bool × ByteArray) := do
-  let unpadded ← unpad s
-  let (s', r)  ← decodeCStar unpadded
-  .some (s', r.toByteArray)
+def decodeBytestring (d : DecodeState) : Option (DecodeState × ByteArray) := do
+  let unpadded ← unpad d
+  let (d', r)  ← decodeCStar unpadded
+  .some (d', r.toByteArray)
 
 /- Decodes a unicode string. -/
 -- Spec C.2.6. Strings
-def decodeUnicode (s : List Bool) : Option (List Bool × String) := do
-  let (s', b) ← decodeBytestring s
+def decodeUnicode (d : DecodeState) : Option (DecodeState × String) := do
+  let (d', b) ← decodeBytestring d
   let u       ← Except.toOption (decodeUtf8 (byteArrayToByteString b))
-  .some (s', u)
+  .some (d', u)
 
 /- Decodes a Bool value. -/
-def decodeBool : List Bool → Option (List Bool × Bool)
-  | b :: s => .some (s, b)
-  | _      => .none
+def decodeBool (d : DecodeState) : Option (DecodeState × Bool) := do
+  let b ← d.nextBit
+  .some (d.advance, b)
 
 partial def decodeConstType : List Nat → Option (List Nat × BuiltinType)
   | 0           :: l => .some (l, .AtomicType .TypeInteger)
@@ -125,50 +169,52 @@ partial def decodeConstType : List Nat → Option (List Nat × BuiltinType)
   | 8           :: l => .some (l, .AtomicType .TypeData)
   | _      => .none
 
-partial def decodeConstValue (s : List Bool) : BuiltinType → Option (List Bool × Const)
-  | .AtomicType .TypeInteger        => Prod.map id .Integer <$> decodeInt s
-  | .AtomicType .TypeByteString     => Prod.map id (.ByteString ∘ byteArrayToByteString) <$> decodeBytestring s
-  | .AtomicType .TypeString         => Prod.map id .String <$> decodeUnicode s
-  | .AtomicType .TypeUnit           => .some (s, .Unit)
-  | .AtomicType .TypeBool           => Prod.map id .Bool <$> decodeBool s
+partial def decodeConstValue (d : DecodeState) : BuiltinType → Option (DecodeState × Const)
+  | .AtomicType .TypeInteger        => Prod.map id .Integer <$> decodeInt d
+  | .AtomicType .TypeByteString     => Prod.map id (.ByteString ∘ byteArrayToByteString) <$> decodeBytestring d
+  | .AtomicType .TypeString         => Prod.map id .String <$> decodeUnicode d
+  | .AtomicType .TypeUnit           => .some (d, .Unit)
+  | .AtomicType .TypeBool           => Prod.map id .Bool <$> decodeBool d
   | .AtomicType .TypeData           => do
-      let (s', t) ← decodeBytestring s
-      let (_ , d) ← decodeData t
-      .some (s', .Data d)
+      let (d', t) ← decodeBytestring d
+      let (_ , da) ← decodeData t
+      .some (d', .Data da)
   | .TypeOperator (.TypeList t)     =>
        match t with
        | .AtomicType .TypeData =>
-             let decodeConstData (xs : List Bool) : Option (List Bool × Data) :=
+             let decodeConstData (xs : DecodeState) : Option (DecodeState × Data) :=
                match decodeConstValue xs t with
-               | some (xs', Const.Data d) => some (xs', d)
-               | _ => none -- don't produce anything on type mismatched
-             Prod.map id Const.ConstDataList <$> decodeList decodeConstData s
+               | some (xs', Const.Data da) => some (xs', da)
+               | _                         => none -- don't produce anything on type mismatched
+             Prod.map id Const.ConstDataList <$> decodeList decodeConstData d
        | .TypeOperator (.TypePair (.AtomicType .TypeData) (.AtomicType .TypeData)) =>
-             let decodeConstPairData (xs : List Bool) : Option (List Bool × (Data × Data)) :=
+             let decodeConstPairData (xs : DecodeState) : Option (DecodeState × (Data × Data)) :=
                match decodeConstValue xs t with
                | some (xs', Const.PairData p) => some (xs', p)
-               | _ => none -- don't produce anything on type mismatched
-             Prod.map id .ConstPairDataList <$> decodeList decodeConstPairData s
-       | _ => Prod.map id Const.ConstList <$> decodeList (flip decodeConstValue t) s -- heterogenous list
+               | _                            => none -- don't produce anything on type mismatched
+             Prod.map id .ConstPairDataList <$> decodeList decodeConstPairData d
+       | _ =>
+             Prod.map id Const.ConstList <$> decodeList (flip decodeConstValue t) d -- heterogenous list
   | .TypeOperator (.TypePair t₁ t₂) => do
-      let (s₁, c₁) ← decodeConstValue s  t₁
-      let (s₂, c₂) ← decodeConstValue s₁ t₂
+      let (d₁, c₁) ← decodeConstValue d  t₁
+      let (d₂, c₂) ← decodeConstValue d₁ t₂
       match t₁, t₂ with
       | .AtomicType .TypeData, .AtomicType .TypeData =>
           match c₁, c₂ with
-          | Const.Data d₁, Const.Data d₂ => some (s₂, Const.PairData (d₁, d₂))
-          | _, _ => none
-      | _, _ => some (s₂, Const.Pair (c₁, c₂))
+          | Const.Data da₁, Const.Data da₂ => some (d₂, Const.PairData (da₁, da₂))
+          | _             , _              => none
+      | _                    , _                     =>
+          some (d₂, Const.Pair (c₁, c₂))
   | .AtomicType .TypeBls12_381_G1_element -- BLS values are not serializable
   | .AtomicType .TypeBls12_381_G2_element
   | .AtomicType .TypeBls12_381_MlResult   => none
 
 /- Decodes a constant. -/
-def decodeConst (s : List Bool) : Option (List Bool × Const) := do
-  let (s', l)      ← decodeList (decodeFixedNat 4) s
-  let (l', t)      ← decodeConstType l
-  let _            ← Option.filter (λ () => l' = []) (.some ())
-  decodeConstValue s' t
+def decodeConst (d : DecodeState) : Option (DecodeState × Const) := do
+  let (d', l) ← decodeList (decodeFixedNat 4) d
+  let (l', t) ← decodeConstType l
+  let _       ← Option.filter (λ () => l' = []) (.some ())
+  decodeConstValue d' t
 
 def builtinTable : List (Nat × BuiltinFun) :=
   [
@@ -274,10 +320,10 @@ def builtinTable : List (Nat × BuiltinFun) :=
     -- (99, .UnValueData),
   ]
 
-def decodeBuiltinFun (_v : Version) (s : List Bool) : Option (List Bool × BuiltinFun) := do
-  let (s', n)    ← decodeFixedNat 7 s
+def decodeBuiltinFun (_v : Version) (d : DecodeState) : Option (DecodeState × BuiltinFun) := do
+  let (d', n)    ← decodeFixedNat 7 d
   let builtinFun ← List.lookup n builtinTable
-  .some (s', builtinFun)
+  .some (d', builtinFun)
 
 /- Display-only binder name for the lambda introduced at nesting level X. -/
 def varName (debruijn : Nat) : String := s!"dbi_{debruijn}"
@@ -285,96 +331,96 @@ def varName (debruijn : Nat) : String := s!"dbi_{debruijn}"
 /- Decodes a DeBruijn index.
    Flat encodes 1-based relative indices (index 0 is invalid); `Term.Var`
    uses 0-based indices (0 = innermost binder), so we subtract 1. -/
-def decodeVar (s : List Bool) : Option (List Bool × Nat) := do
-  let (s', n) ← decodeNat s
+def decodeVar (nextDebruijn : Nat) (d : DecodeState) : Option (DecodeState × Nat) := do
+  let (d', n) ← decodeNat d
   let _       ← Option.filter (λ () => n > 0) (.some ())
-  .some (s', n - 1)
+  .some (d', n - 1)
 
-/- Decodes a UPLC term.
-   `nextDeBruijn` counts enclosing binders and is used only to synthesize
-   display names for lambdas; variables decode to plain indices. -/
-partial def decodeTerm (v : Version) (nextDeBruijn : Nat) : List Bool → Option (List Bool × Term)
-  | false :: false :: false :: false :: s => Prod.map id .Var                          <$> decodeVar s
-  | false :: false :: false :: true  :: s => Prod.map id .Delay                        <$> decodeTerm v nextDeBruijn s
-  | false :: false :: true  :: false :: s => Prod.map id (.Lam (varName nextDeBruijn)) <$> decodeTerm v (nextDeBruijn + 1) s
-  | false :: false :: true  :: true  :: s => do
-      let (s' , t₁) ← decodeTerm v nextDeBruijn s
-      let (s'', t₂) ← decodeTerm v nextDeBruijn s'
-      .some (s'', .Apply t₁ t₂)
-  | false :: true  :: false :: false :: s => Prod.map id .Const   <$> decodeConst s
-  | false :: true  :: false :: true  :: s => Prod.map id .Force   <$> decodeTerm v nextDeBruijn s
-  | false :: true  :: true  :: false :: s => .some (s, .Error)
-  | false :: true  :: true  :: true  :: s => Prod.map id .Builtin <$> decodeBuiltinFun v s
-  | true  :: false :: false :: false :: s => do
+/- Decodes a UPLC term. -/
+partial def decodeTerm (v : Version) (nextDeBruijn : Nat) (d : DecodeState) : Option (DecodeState × Term) := do
+  let (d, op) ← decodeFixedNat 4 d
+  match op with
+  | 0 => Prod.map id .Var                          <$> decodeVar nextDeBruijn d
+  | 1 => Prod.map id .Delay                        <$> decodeTerm v nextDeBruijn d
+  | 2 => Prod.map id (.Lam (varName nextDeBruijn)) <$> decodeTerm v (nextDeBruijn + 1) d
+  | 3 => do
+      let (d' , t₁) ← decodeTerm v nextDeBruijn d
+      let (d'', t₂) ← decodeTerm v nextDeBruijn d'
+      .some (d'', .Apply t₁ t₂)
+  | 4 => Prod.map id .Const   <$> decodeConst d
+  | 5 => Prod.map id .Force   <$> decodeTerm v nextDeBruijn d
+  | 6 => .some (d, .Error)
+  | 7 => Prod.map id .Builtin <$> decodeBuiltinFun v d
+  | 8 => do
       let _        ← if v < .Version 1 1 0 then .none else .some ()
-      let (s' , i) ← Option.filter (λ (_, i) => i < 2 ^ 64) (decodeNat s)
-      let (s'', l) ← decodeList (decodeTerm v nextDeBruijn) s'
-      .some (s'', .Constr i l)
-  | true  :: false :: false :: true  :: s => do
+      let (d' , i) ← Option.filter (λ (_, i) => i < 2 ^ 64) (decodeNat d)
+      let (d'', l) ← decodeList (decodeTerm v nextDeBruijn) d'
+      .some (d'', .Constr i l)
+  | 9 => do
       let _        ← if v < .Version 1 1 0 then .none else .some ()
-      let (s' , u) ← decodeTerm v nextDeBruijn s
-      let (s'', l) ← decodeList (decodeTerm v nextDeBruijn) s'
-      .some (s'', .Case u l)
+      let (d' , u) ← decodeTerm v nextDeBruijn d
+      let (d'', l) ← decodeList (decodeTerm v nextDeBruijn) d'
+      .some (d'', .Case u l)
   | _ => .none
 
 /- Decodes the Version of the Program. -/
-def decodeVersion (s : List Bool) : Option (List Bool × Version) := do
-  let (s'  , a) ← decodeNat s
-  let (s'' , b) ← decodeNat s'
-  let (s''', c) ← decodeNat s''
-  .some (s''', .Version a b c)
+def decodeVersion (d : DecodeState) : Option (DecodeState × Version) := do
+  let (d'  , a) ← decodeNat d
+  let (d'' , b) ← decodeNat d'
+  let (d''', c) ← decodeNat d''
+  .some (d''', .Version a b c)
 
-/- Decodes a Program from a bit sequence. -/
-def decodeProgramFromBits (s : List Bool) : Option Program := do
-  let (s', version) ← decodeVersion s
-  let (r , t      ) ← decodeTerm version 0 s'
-  let unpadded      ← unpad r
-  let _             ← Option.filter (λ () => unpadded = []) (.some ())
+/- Decodes a Program from a `DecodeState`. -/
+def decodeProgramFromState (d : DecodeState) : Option Program := do
+  let (d' , version) ← decodeVersion d
+  let (d'',  t     ) ← decodeTerm version 0 d'
+  let d'''           ← unpad d''
+  let _              ← Option.filter (λ () => d'''.absBit = d'''.totalBits) (.some ())
   .some (.Program version t)
 
-def bitSequenceFromHexDigit : Char → Option (List Bool)
-  | '0'       => [false, false, false, false]
-  | '1'       => [false, false, false,  true]
-  | '2'       => [false, false,  true, false]
-  | '3'       => [false, false,  true,  true]
-  | '4'       => [false,  true, false, false]
-  | '5'       => [false,  true, false,  true]
-  | '6'       => [false,  true,  true, false]
-  | '7'       => [false,  true,  true,  true]
-  | '8'       => [ true, false, false, false]
-  | '9'       => [ true, false, false,  true]
-  | 'a' | 'A' => [ true, false,  true, false]
-  | 'b' | 'B' => [ true, false,  true,  true]
-  | 'c' | 'C' => [ true,  true, false, false]
-  | 'd' | 'D' => [ true,  true, false,  true]
-  | 'e' | 'E' => [ true,  true,  true, false]
-  | 'f' | 'F' => [ true,  true,  true,  true]
+/- Decodes a single hex digit to its 4-bit value. -/
+def hexDigitValue : Char → Option Nat
+  | '0'       => .some  0
+  | '1'       => .some  1
+  | '2'       => .some  2
+  | '3'       => .some  3
+  | '4'       => .some  4
+  | '5'       => .some  5
+  | '6'       => .some  6
+  | '7'       => .some  7
+  | '8'       => .some  8
+  | '9'       => .some  9
+  | 'a' | 'A' => .some 10
+  | 'b' | 'B' => .some 11
+  | 'c' | 'C' => .some 12
+  | 'd' | 'D' => .some 13
+  | 'e' | 'E' => .some 14
+  | 'f' | 'F' => .some 15
   | _         => .none
 
-/- Generates a bit sequence for a hex string. -/
-def bitSequenceFromHexString : List Char → List Bool → Option (List Bool)
-  | []           , acc => .some acc
+/- Converts a hex string to a `ByteArray`. Each pair of hex digits becomes one byte.
+   Returns `.none` for odd-length inputs or non-hex characters. -/
+def hexStringToByteArray (s : String) : Option ByteArray :=
+  go s.data #[]
+where
+  go : List Char → Array UInt8 → Option ByteArray
   | h₁ :: h₂ :: t, acc => do
-      let b₁ ← bitSequenceFromHexDigit (Char.toLower h₁)
-      let b₂ ← bitSequenceFromHexDigit (Char.toLower h₂)
-      bitSequenceFromHexString t (acc ++ b₁ ++ b₂)
+      let v₁ ← hexDigitValue h₁
+      let v₂ ← hexDigitValue h₂
+      go t (acc.push (16 * v₁ + v₂).toUInt8)
+  | []           , acc => .some ⟨acc⟩
   | _            , _   => .none
-
-/- Generates a bit sequence for a list of bytes. -/
-def bitSequenceFromBytes : List UInt8 → List Bool → Option (List Bool)
-  | []    , acc => .some acc
-  | c :: t, acc =>
-      let b   := c.toBitVec
-      let bcc := [b.getLsb 7, b.getLsb 6, b.getLsb 5, b.getLsb 4, b.getLsb 3, b.getLsb 2, b.getLsb 1, b.getLsb 0]
-      bitSequenceFromBytes t (acc ++ bcc)
 
 /- Decodes a Program from a hex string. -/
 def decodeProgramFromHexString (hexString : String) : Option Program :=
-  bitSequenceFromHexString hexString.data [] >>= decodeProgramFromBits
+  hexStringToByteArray hexString >>= decodeProgramFromByteArray
+where
+  decodeProgramFromByteArray (b : ByteArray) : Option Program :=
+    decodeProgramFromState { input := b, bytePos := 0, bitPos := 0 }
 
 /- Decodes a Program from a `ByteArray`. -/
 def decodeProgramFromByteArray (b : ByteArray) : Option Program :=
-  bitSequenceFromBytes b.toList [] >>= decodeProgramFromBits
+  decodeProgramFromState { input := b, bytePos := 0, bitPos := 0 }
 
 end Internal
 

--- a/PlutusCore/UPLC/FlatEncoding/Basic.lean
+++ b/PlutusCore/UPLC/FlatEncoding/Basic.lean
@@ -9,7 +9,7 @@ import PlutusCore.UPLC.Term
 namespace PlutusCore.UPLC.FlatEncoding
 
 open PlutusCore.ByteString (ByteString)
-open PlutusCore.Cbor (decodeData)
+open PlutusCore.Cbor (byteArrayToByteString decodeData)
 open PlutusCore.Data (Data)
 open PlutusCore.Integer (Integer)
 open PlutusCore.String (decodeUtf8)
@@ -70,19 +70,19 @@ def decodeInt (s : List Bool) : Option (List Bool × Integer) := do
 
 -- Spec C.2.5. Bytestrings
 -- D_C^(n)
-def decodeChunk : Nat → List Bool → List Char  → Option (List Bool × List Char)
+def decodeChunk : Nat → List Bool → List UInt8 → Option (List Bool × List UInt8)
   | .zero  , s, l => .some (s, List.reverse l)
   | .succ p, s, l => do
       let (s', x) ← decodeFixedNat 8 s
-      decodeChunk p s' ((Char.ofNat x) :: l)
+      decodeChunk p s' (x.toUInt8 :: l)
 
 -- D_C
-def decodeChunks (s : List Bool) : Option (List Bool × List Char) := do
+def decodeChunks (s : List Bool) : Option (List Bool × List UInt8) := do
   let (s', n) ← decodeFixedNat 8 s
   decodeChunk n s' []
 
 -- D_C*
-partial def decodeCStar (s : List Bool) : Option (List Bool × List Char) := do
+partial def decodeCStar (s : List Bool) : Option (List Bool × List UInt8) := do
   let (s', x) ← decodeChunks s
   match x with
   | [] => .some (s', [])
@@ -91,16 +91,16 @@ partial def decodeCStar (s : List Bool) : Option (List Bool × List Char) := do
       .some (s'', x ++ l)
 
 /- Decodes a Bytestring. -/
-def decodeBytestring (s : List Bool) : Option (List Bool × String) := do
+def decodeBytestring (s : List Bool) : Option (List Bool × ByteArray) := do
   let unpadded ← unpad s
   let (s', r)  ← decodeCStar unpadded
-  .some (s', ⟨r⟩)
+  .some (s', r.toByteArray)
 
 /- Decodes a unicode string. -/
 -- Spec C.2.6. Strings
 def decodeUnicode (s : List Bool) : Option (List Bool × String) := do
   let (s', b) ← decodeBytestring s
-  let u       ← Except.toOption (decodeUtf8 b)
+  let u       ← Except.toOption (decodeUtf8 (byteArrayToByteString b))
   .some (s', u)
 
 /- Decodes a Bool value. -/
@@ -126,11 +126,11 @@ partial def decodeConstType : List Nat → Option (List Nat × BuiltinType)
   | _      => .none
 
 partial def decodeConstValue (s : List Bool) : BuiltinType → Option (List Bool × Const)
-  | .AtomicType .TypeInteger        => Prod.map id .Integer                      <$> decodeInt s
-  | .AtomicType .TypeByteString     => Prod.map id (.ByteString ∘ ByteString.mk) <$> decodeBytestring s
-  | .AtomicType .TypeString         => Prod.map id .String                       <$> decodeUnicode s
+  | .AtomicType .TypeInteger        => Prod.map id .Integer <$> decodeInt s
+  | .AtomicType .TypeByteString     => Prod.map id (.ByteString ∘ byteArrayToByteString) <$> decodeBytestring s
+  | .AtomicType .TypeString         => Prod.map id .String <$> decodeUnicode s
   | .AtomicType .TypeUnit           => .some (s, .Unit)
-  | .AtomicType .TypeBool           => Prod.map id .Bool                         <$> decodeBool s
+  | .AtomicType .TypeBool           => Prod.map id .Bool <$> decodeBool s
   | .AtomicType .TypeData           => do
       let (s', t) ← decodeBytestring s
       let (_ , d) ← decodeData t
@@ -360,28 +360,28 @@ def bitSequenceFromHexString : List Char → List Bool → Option (List Bool)
       bitSequenceFromHexString t (acc ++ b₁ ++ b₂)
   | _            , _   => .none
 
-/- Generates a bit sequence for a byte string. -/
-def bitSequenceFromByteString : List Char → List Bool → Option (List Bool)
+/- Generates a bit sequence for a list of bytes. -/
+def bitSequenceFromBytes : List UInt8 → List Bool → Option (List Bool)
   | []    , acc => .some acc
   | c :: t, acc =>
-      let b   := c |> Char.toUInt8 |> UInt8.toBitVec
+      let b   := c.toBitVec
       let bcc := [b.getLsb 7, b.getLsb 6, b.getLsb 5, b.getLsb 4, b.getLsb 3, b.getLsb 2, b.getLsb 1, b.getLsb 0]
-      bitSequenceFromByteString t (acc ++ bcc)
+      bitSequenceFromBytes t (acc ++ bcc)
 
 /- Decodes a Program from a hex string. -/
 def decodeProgramFromHexString (hexString : String) : Option Program :=
   bitSequenceFromHexString hexString.data [] >>= decodeProgramFromBits
 
-/- Decodes a Program from a byte string. -/
-def decodeProgramFromByteString (s : String) : Option Program :=
-  bitSequenceFromByteString s.data [] >>= decodeProgramFromBits
+/- Decodes a Program from a `ByteArray`. -/
+def decodeProgramFromByteArray (b : ByteArray) : Option Program :=
+  bitSequenceFromBytes b.toList [] >>= decodeProgramFromBits
 
 end Internal
 
 export Internal
   (
     decodeProgramFromHexString
-    decodeProgramFromByteString
+    decodeProgramFromByteArray
   )
 
 end PlutusCore.UPLC.FlatEncoding

--- a/PlutusCore/UPLC/FlatEncoding/Tests.lean
+++ b/PlutusCore/UPLC/FlatEncoding/Tests.lean
@@ -5,17 +5,45 @@ namespace PlutusCore.UPLC.FlatEncoding
 open PlutusCore.UPLC.Term
 open PlutusCore.UPLC.FlatEncoding.Internal
 
-example : decodeFixedNat 8 [true, true, true, true, false, false, false, false] = .some ([], 0xF0)      := by rfl
-example : decodeFixedNat 7 [true, true, true, true, false, false, false, false] = .some ([false], 0x78) := by rfl
+/-- Test helper: pack a `List Bool` (MSB-first within each byte) into a `ByteArray`.
+    Trailing bits beyond a multiple of 8 are zero-padded on the low end of the last byte. -/
+private def bitsToByteArray (bs : List Bool) : ByteArray :=
+  let n         := bs.length
+  let byteCount := (n + 7) / 8
+  let padded    := bs ++ List.replicate (byteCount * 8 - n) false
+  let bytes     := (List.range byteCount).map (fun i =>
+    ((padded.drop (i * 8)).take 8).foldl
+      (fun (acc : UInt8) b => (acc <<< 1) ||| (if b then 1 else 0)) 0)
+  ⟨bytes.toArray⟩
 
-example : decodeList (decodeFixedNat 2) [true, false, true, true, true, false, false] = .some ([], [1, 2]) := by native_decide
+/-- Test helper: build a `DecodeState` at position 0 from a `List Bool`. -/
+private def stateOfBits (bs : List Bool) : DecodeState :=
+  { input := bitsToByteArray bs, bytePos := 0, bitPos := 0 }
 
-example : decodeNat [false, false, true, false, true, false, true, false] = .some ([], 42) := by native_decide
-example : decodeNat ([true]  ++ [true , true , true , true , true , true , true ]
-                  ++ [false] ++ [false, false, false, false, false, false, true ]) = .some ([], 255) := by native_decide
-example : decodeNat ([true]  ++ [false, false, false, false, false, false, false]
-                  ++ [true]  ++ [false, false, false, false, false, false, false]
-                  ++ [false] ++ [false, false, false, false, false, false, true ]) = .some ([], 16384) := by native_decide
+example :
+    decodeFixedNat 8 (stateOfBits [true, true, true, true, false, false, false, false])
+    = .some ({ input := bitsToByteArray [true, true, true, true, false, false, false, false], bytePos := 1, bitPos := 0 }, 0xF0) := by native_decide
+
+example :
+    decodeFixedNat 7 (stateOfBits [true, true, true, true, false, false, false, false])
+    = .some ({ input := bitsToByteArray [true, true, true, true, false, false, false, false], bytePos := 0, bitPos := 7 }, 0x78) := by native_decide
+
+example :
+    (decodeList (decodeFixedNat 2) (stateOfBits [true, false, true, true, true, false, false])).map Prod.snd
+    = .some [1, 2] := by native_decide
+
+example :
+    (decodeNat (stateOfBits [false, false, true, false, true, false, true, false])).map Prod.snd
+    = .some 42 := by native_decide
+example :
+    (decodeNat (stateOfBits ([true]  ++ [true , true , true , true , true , true , true ]
+                          ++ [false] ++ [false, false, false, false, false, false, true ]))).map Prod.snd
+    = .some 255 := by native_decide
+example :
+    (decodeNat (stateOfBits ([true]  ++ [false, false, false, false, false, false, false]
+                          ++ [true]  ++ [false, false, false, false, false, false, false]
+                          ++ [false] ++ [false, false, false, false, false, false, true ]))).map Prod.snd
+    = .some 16384 := by native_decide
 
 -- Spec C.5. Example
 

--- a/PlutusCore/UPLC/ScriptEncoding/Basic.lean
+++ b/PlutusCore/UPLC/ScriptEncoding/Basic.lean
@@ -8,7 +8,7 @@ import PlutusCore.UPLC.TextEncoding
 
 namespace PlutusCore.UPLC.ScriptEncoding
 
-open FlatEncoding (decodeProgramFromByteString)
+open FlatEncoding (decodeProgramFromByteArray)
 open PlutusCore.Cbor (decodeLargeBytestring)
 open PlutusCore.UPLC.TextEncoding (programFromString)
 open PlutusScript
@@ -38,13 +38,18 @@ def hexDigitValue : Char → Option Nat
   | 'f' | 'F' => .some 15
   | _   => .none
 
-/-- Convert a sequence of hexadecimal digits to their base 256 representation (bytestring). -/
-partial def hexStringToString : List Char -> List Char → Option (List Char)
+/-- Convert a sequence of hexadecimal digits to the corresponding `ByteArray`.
+    Each pair of hex digits becomes one byte. Returns `.none` if the input has
+    an odd length or contains a non-hex character. -/
+partial def hexStringToByteArray (s : String) : Option ByteArray :=
+  go s.data []
+where
+  go : List Char → List UInt8 → Option ByteArray
   | h₁ :: h₂ :: t, acc =>
       match hexDigitValue h₁, hexDigitValue h₂ with
-      | .some h, .some l => hexStringToString t (Char.ofNat (16 * h + l) :: acc)
+      | .some h, .some l => go t ((16 * h + l).toUInt8 :: acc)
       | _      , _       => .none
-  | []           , acc => .some (List.reverse acc)
+  | []           , acc => .some acc.reverse.toByteArray
   | _            , _   => .none
 
 /-- Helper function to simplify adding error messages to computations resulting in `Option` values. -/
@@ -65,9 +70,9 @@ def fromStringTermElaborator {α} [ToExpr α] (fn : String → Except String α)
 
 /-- Decodes an UPLC program from it's single-cbor-encoded hexadecimal representation. -/
 def singleCborEncodedScriptFromHex? (s : String) : Except String Program := do
-  let hexDecoded       ← Option.toExcept (hexStringToString s.data [])             "Could not hexdecode input!"
-  let (_, decodedCbor) ← Option.toExcept (decodeLargeBytestring ⟨hexDecoded⟩)      "Could not cbor decode input!"
-  let program          ← Option.toExcept (decodeProgramFromByteString decodedCbor) "Could not decode program!"
+  let bytes            ← Option.toExcept (hexStringToByteArray s)                 "Could not hexdecode input!"
+  let (_, decodedCbor) ← Option.toExcept (decodeLargeBytestring bytes)            "Could not cbor decode input!"
+  let program          ← Option.toExcept (decodeProgramFromByteArray decodedCbor) "Could not decode program!"
   return program
 
 /-- Decodes an UPLC program from it's single-cbor-encoded hexadecimal representation.
@@ -83,10 +88,10 @@ def elabSingleCborEncodedScriptFromHexM : TermElab := fromStringTermElaborator s
 
 /-- Decodes an UPLC program from it's double-cbor-encoded hexadecimal representation. -/
 def doubleCborEncodedScriptFromHex? (s : String) : Except String Program := do
-  let hexDecoded        ← Option.toExcept (hexStringToString s.data [])              "Could not hexdecode input!"
-  let (_, decodedCbor₁) ← Option.toExcept (decodeLargeBytestring ⟨hexDecoded⟩)       "Could not cbor decode input (first pass)!"
-  let (_, decodedCbor₂) ← Option.toExcept (decodeLargeBytestring decodedCbor₁)       "Could not cbor decode input (second pass)!"
-  let program           ← Option.toExcept (decodeProgramFromByteString decodedCbor₂) "Could not decode program!"
+  let bytes             ← Option.toExcept (hexStringToByteArray s)                  "Could not hexdecode input!"
+  let (_, decodedCbor₁) ← Option.toExcept (decodeLargeBytestring bytes)             "Could not cbor decode input (first pass)!"
+  let (_, decodedCbor₂) ← Option.toExcept (decodeLargeBytestring decodedCbor₁)      "Could not cbor decode input (second pass)!"
+  let program           ← Option.toExcept (decodeProgramFromByteArray decodedCbor₂) "Could not decode program!"
   return program
 
 /-- Decodes an UPLC program from it's double-cbor-encoded hexadecimal representation.
@@ -101,24 +106,17 @@ syntax (name := doubleCborEncodedScriptFromHexMacro) "doubleCborEncodedScriptFro
 def elabDoubleCborEncodedScriptFromHexM : TermElab := fromStringTermElaborator doubleCborEncodedScriptFromHex?
 
 /-- Decodes an UPLC program from it's raw flat representation. -/
-def flatEncodedScriptFromBytestring? (b : String) : Except String Program :=
-  Option.toExcept (decodeProgramFromByteString b) "Could not decode program!"
+def flatEncodedScriptFromByteArray? (b : ByteArray) : Except String Program :=
+  Option.toExcept (decodeProgramFromByteArray b) "Could not decode program!"
 
 /-- Decodes an UPLC program from it's raw flat representation.
     Panics if the script cannot be decoded. -/
-def flatEncodedScriptFromBytestring! (b : String) : Program := Except.orDie! (flatEncodedScriptFromBytestring? b)
-
-/-- Macro version of flatEncodedScriptFromByteString.
-    Implemented as a term elaborator, generates the program as a Lean term. -/
-syntax (name := flatEncodedScriptFromBytestringMacro) "flatEncodedScriptFromBytestringM" str : term
-
-@[term_elab flatEncodedScriptFromBytestringMacro]
-def elabFlatEncodedScriptFromBytestringM : TermElab := fromStringTermElaborator flatEncodedScriptFromBytestring?
+def flatEncodedScriptFromByteArray! (b : ByteArray) : Program := Except.orDie! (flatEncodedScriptFromByteArray? b)
 
 /-- Decodes an UPLC program from it's flat hexadecimal representation. -/
 def flatEncodedScriptFromHex? (s : String) : Except String Program := do
-  let hexDecoded ← Option.toExcept (hexStringToString s.data [])              "Could not hexdecode input!"
-  let program    ← Option.toExcept (decodeProgramFromByteString ⟨hexDecoded⟩) "Could not decode program!"
+  let bytes   ← Option.toExcept (hexStringToByteArray s)           "Could not hexdecode input!"
+  let program ← Option.toExcept (decodeProgramFromByteArray bytes) "Could not decode program!"
   return program
 
 /-- Decodes an UPLC program from it's flat hexadecimal representation.
@@ -146,6 +144,31 @@ Example:
 ```
 -/
 syntax (name := import_uplc) "#import_uplc" ident ident ident str : command
+
+/-- Cached representations of a file's contents.
+    Binary formats need raw bytes; textual/hex formats need UTF-8 text.
+    Whichever representation a parser already read is reused; the other is
+    loaded lazily by the format-suggestion helper if needed. -/
+structure FileContents where
+  path : System.FilePath
+  text : Option String     := .none
+  bin  : Option ByteArray  := .none
+
+/-- Returns the UTF-8 text of the file, reading it if not already loaded. -/
+def FileContents.getText (fc : FileContents) : IO (FileContents × String) :=
+  match fc.text with
+  | some t => pure (fc, t)
+  | none   => do
+      let t ← IO.FS.readFile fc.path
+      pure ({ fc with text := some t }, t)
+
+/-- Returns the raw byte contents of the file, reading it if not already loaded. -/
+def FileContents.getBin (fc : FileContents) : IO (FileContents × ByteArray) :=
+  match fc.bin with
+  | some b => pure (fc, b)
+  | none   => do
+      let b ← IO.FS.readBinFile fc.path
+      pure ({ fc with bin := some b }, b)
 
 /-- Elaboration for the #import_uplc command -/
 @[command_elab import_uplc]
@@ -185,28 +208,25 @@ def importUplcImp : CommandElab := fun stx => do
     let some s := f.isStrLit? | throwErrorAt f m!"string literal expected for filename"
     return s
 
-  /-- Tries to decode content with all formats and returns the first one that succeeds.
-      Hex-based formats are checked against the trimmed content to mirror the
-      real decoders (which call `String.trim` before decoding). -/
-  findWorkingFormat (content : String) : Option Name :=
-    let trimmed := String.trim content
-    -- Try textual
-    if (programFromString content).isOk then
-      some `textual
-    -- Try flat
-    else if (decodeProgramFromByteString content).isSome then
-      some `flat
-    -- Try flat_hex
-    else if (flatEncodedScriptFromHex? trimmed).isOk then
-      some `flat_hex
-    -- Try single_cbor_hex
-    else if (singleCborEncodedScriptFromHex? trimmed).isOk then
-      some `single_cbor_hex
-    -- Try double_cbor_hex
-    else if (doubleCborEncodedScriptFromHex? trimmed).isOk then
-      some `double_cbor_hex
-    else
-      none
+  /-- Tries to decode the file's contents in every supported format and returns
+      the first one that succeeds. Lazily loads either the textual or the binary
+      representation depending on what each format needs, reusing whatever
+      representation the caller already loaded. -/
+  findWorkingFormat (fc : FileContents) : IO (Option Name) := do
+    -- Try textual (needs text)
+    let (fc, text) ← fc.getText
+    if (programFromString text).isOk then return some `textual
+    -- Try flat (needs binary)
+    let (_, bin) ← fc.getBin
+    if (decodeProgramFromByteArray bin).isSome then return some `flat
+    let trimmed := text.trim
+    -- Try flat_hex (needs text)
+    if (flatEncodedScriptFromHex? trimmed).isOk then return some `flat_hex
+    -- Try single_cbor_hex (needs text)
+    if (singleCborEncodedScriptFromHex? trimmed).isOk then return some `single_cbor_hex
+    -- Try double_cbor_hex (needs text)
+    if (doubleCborEncodedScriptFromHex? trimmed).isOk then return some `double_cbor_hex
+    return none
 
   /-- Formats a format name as a suggestion string -/
   formatSuggestion (format : Name) : String :=
@@ -214,79 +234,83 @@ def importUplcImp : CommandElab := fun stx => do
     s!"Did you mean '{formatName}'?"
 
   /-- Creates an error message with format suggestions for decoding failures -/
-  decodingErrorWithSuggestion (content : String) (excludeFormat : Name) (filename : String) (errorMsg? : Option String := none) : String :=
-    let suggestion := match findWorkingFormat content with
-      | some fmt => if fmt != excludeFormat then formatSuggestion fmt else ""
-      | none => ""
+  decodingErrorWithSuggestion (fc : FileContents) (excludeFormat : Name) (errorMsg? : Option String := none) : TermElabM String := do
+    let alt? ← (findWorkingFormat fc).toBaseIO
+    let suggestion := match alt? with
+      | .ok (some fmt) => if fmt != excludeFormat then formatSuggestion fmt else ""
+      | _ => ""
     let baseMsg := match errorMsg? with
-      | some msg => s!"Decoding error in '{filename}': {msg}"
-      | none => s!"Decoding error in '{filename}'"
-    if suggestion.isEmpty then baseMsg else s!"{baseMsg}. {suggestion}"
-
-  /-- Reads file at path `filename` contents as text. -/
-  readFileContents (filename : String) : TermElabM String :=
-    liftM $ do
-      let path := System.FilePath.mk filename
-      IO.FS.readFile path
+      | some msg => s!"Decoding error in '{fc.path}': {msg}"
+      | none     => s!"Decoding error in '{fc.path}'"
+    return if suggestion.isEmpty then baseMsg else s!"{baseMsg}. {suggestion}"
 
   /-- Parses a textual UPLC file and returns the resulting expression -/
   parseTextualUplc (filename : String) : TermElabM Expr := do
-    let content ← readFileContents filename
+    let path := System.FilePath.mk filename
+    let content ← liftM <| IO.FS.readFile path
     match programFromString content with
     | .ok p =>
         logInfo s!"Successfully decoded textual '{filename}'"
         return (toExpr p)
     | .error msg =>
-        throwError (decodingErrorWithSuggestion content `textual filename (some msg))
+        let fc : FileContents := { path, text := some content }
+        let msg' ← decodingErrorWithSuggestion fc `textual (some msg)
+        throwError msg'
 
   /-- Parses a flat-encoded UPLC file and returns the resulting expression -/
   parseFlatUplc (filename : String) : TermElabM Expr := do
-    let content ← readFileContents filename
-    match decodeProgramFromByteString content with
+    let path := System.FilePath.mk filename
+    let bytes ← liftM <| IO.FS.readBinFile path
+    match decodeProgramFromByteArray bytes with
     | .some p =>
         logInfo s!"Successfully decoded flat '{filename}'"
         return (toExpr p)
     | .none =>
-        throwError (decodingErrorWithSuggestion content `flat filename)
+        let fc : FileContents := { path, bin := some bytes }
+        let msg' ← decodingErrorWithSuggestion fc `flat
+        throwError msg'
 
   /-- Parses a flat hex-encoded UPLC file and returns the resulting expression -/
   parseFlatHexUplc (filename : String) : TermElabM Expr := do
-    let content ← liftM $ do
-      let path := System.FilePath.mk filename
-      IO.FS.readFile path
+    let path := System.FilePath.mk filename
+    let content ← liftM <| IO.FS.readFile path
     let content' := String.trim content
     match flatEncodedScriptFromHex? content' with
     | .ok p =>
         logInfo s!"Successfully decoded flat hex '{filename}'"
         return (toExpr p)
     | .error msg =>
-        throwError (decodingErrorWithSuggestion content' `flat_hex filename (some msg))
+        let fc : FileContents := { path, text := some content }
+        let msg' ← decodingErrorWithSuggestion fc `flat_hex (some msg)
+        throwError msg'
 
   /-- Parses a single CBOR hex-encoded UPLC file and returns the resulting expression -/
   parseSingleCborHexUplc (filename : String) : TermElabM Expr := do
-    let content ← liftM $ do
-      let path := System.FilePath.mk filename
-      IO.FS.readFile path
+    let path := System.FilePath.mk filename
+    let content ← liftM <| IO.FS.readFile path
     let content' := String.trim content
     match singleCborEncodedScriptFromHex? content' with
     | .ok p =>
         logInfo s!"Successfully decoded single CBOR hex '{filename}'"
         return (toExpr p)
     | .error msg =>
-        throwError (decodingErrorWithSuggestion content' `single_cbor_hex filename (some msg))
+        let fc : FileContents := { path, text := some content }
+        let msg' ← decodingErrorWithSuggestion fc `single_cbor_hex (some msg)
+        throwError msg'
 
   /-- Parses a double CBOR hex-encoded UPLC file and returns the resulting expression -/
   parseDoubleCborHexUplc (filename : String) : TermElabM Expr := do
-    let content ← liftM $ do
-      let path := System.FilePath.mk filename
-      IO.FS.readFile path
+    let path := System.FilePath.mk filename
+    let content ← liftM <| IO.FS.readFile path
     let content' := String.trim content
     match doubleCborEncodedScriptFromHex? content' with
     | .ok p =>
         logInfo s!"Successfully decoded double CBOR hex '{filename}'"
         return (toExpr p)
     | .error msg =>
-        throwError (decodingErrorWithSuggestion content' `double_cbor_hex filename (some msg))
+        let fc : FileContents := { path, text := some content }
+        let msg' ← decodingErrorWithSuggestion fc `double_cbor_hex (some msg)
+        throwError msg'
 
   /-- Parses a UPLC file and returns the resulting expression based on format -/
   parseUplcFile (stx : Syntax) : TermElabM Expr := do
@@ -309,7 +333,7 @@ end Internal
 export Internal
   ( singleCborEncodedScriptFromHex!
     doubleCborEncodedScriptFromHex!
-    flatEncodedScriptFromBytestring!
+    flatEncodedScriptFromByteArray!
     flatEncodedScriptFromHex!
   )
 

--- a/PlutusCore/UPLC/ScriptEncoding/Tests.lean
+++ b/PlutusCore/UPLC/ScriptEncoding/Tests.lean
@@ -70,12 +70,7 @@ def test11 := doubleCborEncodedScriptFromHexM "494801000022212001011"
 /-- info: Program.Program (Version.Version 1 0 0)
   (Term.Lam "dbi_0" (Term.Lam "dbi_1" (Term.Lam "dbi_2" (Term.Lam "dbi_3" (Term.Var 0)).Delay))) -/
 #guard_msgs in
-#eval flatEncodedScriptFromBytestring! "\x01\x00\x00\x22\x21\x20\x01\x01"
-
-/-- info: Program.Program (Version.Version 1 0 0)
-  (Term.Lam "dbi_0" (Term.Lam "dbi_1" (Term.Lam "dbi_2" (Term.Lam "dbi_3" (Term.Var 0)).Delay))) -/
-#guard_msgs in
-#eval flatEncodedScriptFromBytestringM "\x01\x00\x00\x22\x21\x20\x01\x01"
+#eval flatEncodedScriptFromByteArray! (ByteArray.mk #[0x01, 0x00, 0x00, 0x22, 0x21, 0x20, 0x01, 0x01])
 
 /-- info: Successfully decoded flat 'PlutusCore/UPLC/ScriptEncoding/TestsFlat/testUplc.flat' -/
 #guard_msgs in


### PR DESCRIPTION
## Description

Refactor binary script decoders and cbor encoders to use ByteArray for consistency.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Performance improvement
- [x] Code refactoring
- [ ] Test updates

## Related Issue

- Closes https://github.com/input-output-hk/Lean-blaster/issues/122

## Changes Made

- Updated CBOR to encode/decode to/from ByteArrays instead of Strings.
- Updated Flat decoder to read from ByteArrays.

## Testing

Adapted existing tests to use the new format; conformance tests work without modification.

### Test Coverage

- [x] Added new tests for new functionality
- [x] Updated existing tests
- [x] All tests pass locally

## Documentation

- [x] README updated (if applicable)
- [x] Code comments added/updated
- [x] Doc comments added for new optimization/rewritting rules

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes using `make check_all`
