### PR TITLE
Refactor Cryptograph to use ByteArrays

### DIFF
--- a/Cryptograph/BLS12_381/Basic.lean
+++ b/Cryptograph/BLS12_381/Basic.lean
@@ -143,7 +143,7 @@ instance {α β} [LE α] [LE β] [DecidableLE α] [DecidableLE β] : LE (α × �
   le x y := leProd x y
 
 instance {α β} [LE α] [LE β] [DecidableLE α] [DecidableLE β] : (x y : α × β) → Decidable (x ≤ y) :=
-  fun x y => inferInstanceAs (Decidable (leProd x y))
+  λ x y => inferInstanceAs (Decidable (leProd x y))
 
 def Fq2.inv (x : Fq2) : Fq2 :=
   let f := (x.u1 * x.u1 + x.u0 * x.u0)⁻¹
@@ -166,7 +166,7 @@ instance : Field Fq2 where
   mulByNonResidual := Fq2.mulByNonResidual
 
 instance : (x y : Fq2) → Decidable (x ≤ y) :=
-  fun x y => inferInstanceAs (Decidable ((x.u1, x.u0) ≤ (y.u1, y.u0)))
+  λ x y => inferInstanceAs (Decidable ((x.u1, x.u0) ≤ (y.u1, y.u0)))
 
 def Fq6.add (x y : Fq6) : Fq6 := ⟨x.v2 + y.v2, x.v1 + y.v1, x.v0 + y.v0⟩
 def Fq6.sub (x y : Fq6) : Fq6 := ⟨x.v2 - y.v2, x.v1 - y.v1, x.v0 - y.v0⟩
@@ -200,7 +200,7 @@ instance : Field Fq6 where
   mulByNonResidual := Fq6.mulByNonResidual
 
 instance : (x y : Fq6) → Decidable (x ≤ y) :=
-  fun x y => inferInstanceAs (Decidable ((x.v2, x.v1, x.v0) ≤ (y.v2, y.v1, y.v0)))
+  λ x y => inferInstanceAs (Decidable ((x.v2, x.v1, x.v0) ≤ (y.v2, y.v1, y.v0)))
 
 instance : Inhabited Fq12 where
   default := Fq12.ofNat 0
@@ -463,71 +463,64 @@ def Fq2.sqrtMod (n : Fq2) : Residues Fq2 :=
 /- "Hashing to Elliptic Curves" specification: (RFC9380) https://datatracker.ietf.org/doc/rfc9380/ -/
 
 /- RFC9380: I2OSP functions -/
-def i2osp₁ (n : Nat) : UInt8      := UInt8.ofNat n
-def i2osp₂ (n : Nat) : List UInt8 := [ UInt8.ofNat (n >>> 8), UInt8.ofNat n ]
+def i2osp₁ (n : Nat) : UInt8     := UInt8.ofNat n
+def i2osp₂ (n : Nat) : ByteArray := ⟨#[ UInt8.ofNat (n >>> 8), UInt8.ofNat n ]⟩
 
 /- Encode natural number n as exactly len big-endian bytes (i2osp generalised). -/
-def i2ospN (n : Nat) (len : Nat) : List UInt8 :=
-  let rec loop (n : Nat) : Nat → List UInt8
-    | 0     => []
-    | k + 1 => loop (n / 256) k ++ [UInt8.ofNat (n % 256)]
-  loop n len
+def i2ospN (n : Nat) (len : Nat) : ByteArray :=
+  let rec loop (acc : List UInt8) (n : Nat) : Nat → List UInt8
+    | 0     => acc
+    | k + 1 => loop (UInt8.ofNat (n % 256) :: acc) (n / 256) k
+  ⟨(loop [] n len).toArray⟩
 
 /- RFC9380: OS2IP function -/
-def os2ip (x : List UInt8) : Nat :=
-  let rec loop (acc : Nat) : List UInt8 → Nat
-    | []     => acc
-    | h :: t => loop (acc * 256 + (UInt8.toNat h)) t
-  loop 0 x
+def os2ip (x : ByteArray) : Nat :=
+  x.foldl (init := 0) (λ acc h => acc * 256 + h.toNat)
 
 /- RFC9380: strxor function -/
-def strxor (a b : List UInt8) : List UInt8 :=
-  let rec loop (acc : List UInt8) : List UInt8 → List UInt8 → List UInt8
-    | h₁ :: t₁, h₂ :: t₂ => loop ((h₁ ^^^ h₂) :: acc) t₁ t₂
-    | _       , _        => List.reverse acc
-  loop [] a b
+def strxor (a b : ByteArray) : ByteArray :=
+  ⟨Array.zipWith (· ^^^ ·) a.data b.data⟩
 
 /- RFC9380: sgn0 function for G1 -/
 def Fq1.sgn₀ (x : Fq1) : Fin 2 := ⟨x.t % 2, by omega⟩
 
-/- Performs SHA256 hashing on the input message and produces the output as a byte list. -/
-def sha256 (x : List UInt8) : List UInt8 :=
-  List.flatMap UInt32.toUInt8BE (Vector.toList (Sha256.hashMessage x))
+/- Performs SHA256 hashing on the input message and produces the output as a byte array. -/
+def sha256 (x : ByteArray) : ByteArray := Sha256.hashMessage x
 
 /-- Helper function to calculate running hashes of the message. -/
-def expandMessageXmdLoop (acc : List (List UInt8)) (b₀ prev dst' : List UInt8) (ell i : Nat) : List UInt8 :=
+def expandMessageXmdLoop (acc : ByteArray) (b₀ prev dst' : ByteArray) (ell i : Nat) : ByteArray :=
   if i > ell
-    then List.flatten (List.reverse acc)
-    else let next := sha256 ((strxor b₀ prev) ++ [i2osp₁ i] ++ dst')
-         expandMessageXmdLoop (next :: acc) b₀ next dst' ell (i + 1)
+    then acc
+    else let next := sha256 ((strxor b₀ prev) ++ ⟨#[i2osp₁ i]⟩ ++ dst')
+         expandMessageXmdLoop (acc ++ next) b₀ next dst' ell (i + 1)
   termination_by (ell + 1 - i)
   decreasing_by omega
 
 /-- Produces a uniformly random byte string using a cryptographic hash function SHA256.
     (RFC9380: expand_message_xmd). -/
-def expandMessageXmd (msg dst : List UInt8) (l : Nat) : Option (List UInt8) :=
+def expandMessageXmd (msg dst : ByteArray) (l : Nat) : Option ByteArray :=
   let b   := 32
   let s   := 64
   let ell := Int.toNat (((l : Rat) / b).ceil)
-  if ell > 255 ∨ l > 65535 ∨ (List.length dst) > 255
+  if ell > 255 ∨ l > 65535 ∨ dst.size > 255
     then .none
     else
-      let dst'   := dst ++ [i2osp₁ (List.length dst)]
-      let zPad   := List.replicate s (0 : UInt8)
+      let dst'   := dst ++ ⟨#[i2osp₁ dst.size]⟩
+      let zPad   := ⟨Array.replicate s (0 : UInt8)⟩
       let libStr := i2osp₂ l
-      let msg'   := zPad ++ msg ++ libStr ++ [i2osp₁ 0] ++ dst'
+      let msg'   := zPad ++ msg ++ libStr ++ ⟨#[i2osp₁ 0]⟩ ++ dst'
       let b₀     := sha256 msg'
-      let b₁     := sha256 (b₀ ++ [i2osp₁ 1] ++ dst')
-      let uBytes := b₁ ++ expandMessageXmdLoop [] b₀ b₁ dst' ell 2
-      .some (List.take l uBytes)
+      let b₁     := sha256 (b₀ ++ ⟨#[i2osp₁ 1]⟩ ++ dst')
+      let uBytes := b₁ ++ expandMessageXmdLoop .empty b₀ b₁ dst' ell 2
+      .some (uBytes.extract 0 l)
 
 /-- Hashes arbitrary-length byte strings to a pair of Fq1 values.
     (RFC9380: hash_to_field) -/
-def Fq1.hashToField (message dst : List UInt8) : Option (Fq1 × Fq1) := do
+def Fq1.hashToField (message dst : ByteArray) : Option (Fq1 × Fq1) := do
   let l      := 2 * 64
   let uBytes ← expandMessageXmd message dst l
-  let u₀     := os2ip (List.take 64 uBytes)
-  let u₁     := os2ip (List.drop 64 uBytes)
+  let u₀     := os2ip (uBytes.extract 0 64)
+  let u₁     := os2ip (uBytes.extract 64 uBytes.size)
   (Fq1.ofNat u₀, Fq1.ofNat u₁)
 
 /-- Maps a Fq1 value to the modified curve E'.
@@ -647,7 +640,7 @@ def Fq1.clearCofactor (q : Point Fq1) : Point Fq1 :=
 /-- Uniform encoding from byte strings to points on the curve E₁.
     That is, the distribution of its output is statistically close to uniform in the subgroup.
     (RFC9380: hash_to_curve, BLS12381G1_XMD:SHA-256_SSWU_RO_) -/
-def Fq1.hashToCurve (message dst : List UInt8) : Option (Point Fq1) := do
+def Fq1.hashToCurve (message dst : ByteArray) : Option (Point Fq1) := do
   let (u₀, u₁) ← Fq1.hashToField message dst
   let q₀       := Fq1.mapToCurve u₀
   let q₁       := Fq1.mapToCurve u₁
@@ -663,18 +656,18 @@ def Fq2.sgn₀ (x : Fq2) : Fin 2 :=
   if sign₀ ∨ (zero₀ ∧ sign₁) then 1 else 0
 
 /-- Creates an Fq2 value from 128 bytes. -/
-def Fq2.ofBytes (x : List UInt8) : Fq2 :=
-  let x₀ := os2ip (x |> List.take 64)
-  let x₁ := os2ip (x |> List.drop 64 |> List.take 64)
+def Fq2.ofBytes (x : ByteArray) : Fq2 :=
+  let x₀ := os2ip (x.extract 0 64)
+  let x₁ := os2ip (x.extract 64 128)
   ⟨Fq1.ofNat x₁, Fq1.ofNat x₀⟩
 
 /-- Hashes arbitrary-length byte strings to a pair of Fq2 values.
     (RFC9380: hash_to_field) -/
-def Fq2.hashToField (message dst : List UInt8) : Option (Fq2 × Fq2) := do
+def Fq2.hashToField (message dst : ByteArray) : Option (Fq2 × Fq2) := do
   let l      := 2 * 2 * 64
   let uBytes ← expandMessageXmd message dst l
   let u₀     := Fq2.ofBytes uBytes
-  let u₁     := Fq2.ofBytes (List.drop 128 uBytes)
+  let u₁     := Fq2.ofBytes (uBytes.extract 128 uBytes.size)
   (u₀, u₁)
 
 /-- Maps a G2 value to the modified curve E'.
@@ -744,7 +737,7 @@ def Fq2.clearCofactor (q : Point Fq2) : Point Fq2 :=
 /-- Uniform encoding from byte strings to points in E₂.
     That is, the distribution of its output is statistically close to uniform in the subgroup.
     (RFC9380: hash_to_curve, BLS12381G2_XMD:SHA-256_SSWU_RO_) -/
-def Fq2.hashToCurve (message dst : List UInt8) : Option (Point Fq2) := do
+def Fq2.hashToCurve (message dst : ByteArray) : Option (Point Fq2) := do
   let (u₀, u₁) ← Fq2.hashToField message dst
   let q₀       := Fq2.mapToCurve u₀
   let q₁       := Fq2.mapToCurve u₁
@@ -752,7 +745,7 @@ def Fq2.hashToCurve (message dst : List UInt8) : Option (Point Fq2) := do
   let p        := Fq2.clearCofactor r
   p
 
-def Fq1.ofBytesWithCheck (b : List UInt8) : Option Fq1 :=
+def Fq1.ofBytesWithCheck (b : ByteArray) : Option Fq1 :=
   let n := os2ip b
   let x := Fq1.ofNat n
   if x.t.val = n
@@ -765,9 +758,9 @@ def Fq1.findY (x : Fq1) (bigger : Bool) : Option Fq1 :=
   | .one y     => .some y
   | .two y₁ y₂ => if bigger then y₂ else y₁
 
-def Fq2.ofBytesWithCheck (b : List UInt8) : Option Fq2 :=
-  let u₁' := os2ip (List.take 48 b)
-  let u₀' := os2ip (List.drop 48 b)
+def Fq2.ofBytesWithCheck (b : ByteArray) : Option Fq2 :=
+  let u₁' := os2ip (b.extract 0 48)
+  let u₀' := os2ip (b.extract 48 b.size)
   let u₁  := Fq1.ofNat u₁'
   let u₀  := Fq1.ofNat u₀'
   if u₁.t.val = u₁' ∧ u₀.t.val = u₀'
@@ -780,43 +773,44 @@ def Fq2.findY (x : Fq2) (bigger : Bool) : Option Fq2 :=
   | .one y     => .some y
   | .two y₁ y₂ => if bigger then y₂ else y₁
 
-def compressG1 : Point Fq1 → List UInt8
-  | .infinity   => 0b11000000 :: List.replicate 47 0
+def compressG1 : Point Fq1 → ByteArray
+  | .infinity   => ⟨#[(0b11000000 : UInt8)] ++ Array.replicate 47 0⟩
   | .affine x y =>
       -- For a correctly constructed point `findY` should always
       -- result in `some y`.
       let y' := Option.getD (Fq1.findY x false) 0
       let b  := i2ospN x.t.val 48
-      let b0 := b.headD 0
-      let b' := b.tail
+      let b0 := b[0]!
+      let b' := b.extract 1 b.size
       if y ≤ y'
-        then (0b10000000 ||| b0) :: b'
-        else (0b10100000 ||| b0) :: b'
+        then ⟨#[0b10000000 ||| b0]⟩ ++ b'
+        else ⟨#[0b10100000 ||| b0]⟩ ++ b'
 
-def compressG2 : Point Fq2 → List UInt8
-  | .infinity   => 0b11000000 :: List.replicate 95 0
+def compressG2 : Point Fq2 → ByteArray
+  | .infinity   => ⟨#[(0b11000000 : UInt8)] ++ Array.replicate 95 0⟩
   | .affine x y =>
       -- For a correctly constructed point `findY` should always
       -- result in `some y`.
       let y' := Option.getD (Fq2.findY x false) 0
       let b  := i2ospN x.u1.t.val 48 ++ i2ospN x.u0.t.val 48
-      let b0 := b.headD 0
-      let b' := b.tail
+      let b0 := b[0]!
+      let b' := b.extract 1 b.size
       if y ≤ y'
-        then (0b10000000 ||| b0) :: b'
-        else (0b10100000 ||| b0) :: b'
+        then ⟨#[0b10000000 ||| b0]⟩ ++ b'
+        else ⟨#[0b10100000 ||| b0]⟩ ++ b'
 
-def uncompress {α} [Field α] [DecidableEq α] (expectedLength : Nat) (he : expectedLength > 0) (ofBytes : List UInt8 → Option α) (findY : α → Bool → Option α) (b : List UInt8) : Option (Point α) :=
-  if h : List.length b ≠ expectedLength
+def uncompress {α} [Field α] [DecidableEq α] (expectedLength : Nat) (_he : expectedLength > 0) (ofBytes : ByteArray → Option α) (findY : α → Bool → Option α) (b : ByteArray) : Option (Point α) :=
+  if b.size ≠ expectedLength
     then .none
-    else let b0   := List.head b (by grind)
+    else let b0   := b[0]!
          let b₃₈₃ := decide (b0 &&& 0b10000000 > 0)
          let b₃₈₂ := decide (b0 &&& 0b01000000 > 0)
          let b₃₈₁ := decide (b0 &&& 0b00100000 > 0)
          let b0'  := b0 &&& 0b00011111
-         let b'   := b0' :: List.tail b
+         let b'   := ⟨#[b0']⟩ ++ b.extract 1 b.size
          match b₃₈₃, b₃₈₂, b₃₈₁ with
-         | true , true , false => if List.all b' (· = 0) then .some .infinity else .none
+         | true , true , false =>
+             if (List.range b'.size).all (λ i => b'[i]! = 0) then .some .infinity else .none
          | true , false, _     => do
              let x  ← ofBytes b'
              let y  ← findY x b₃₈₁
@@ -826,8 +820,8 @@ def uncompress {α} [Field α] [DecidableEq α] (expectedLength : Nat) (he : exp
                else .none
          | _, _, _ => .none
 
-def uncompressG1 : List UInt8 → Option (Point Fq1) := uncompress 48 (by simp) Fq1.ofBytesWithCheck Fq1.findY
-def uncompressG2 : List UInt8 → Option (Point Fq2) := uncompress 96 (by simp) Fq2.ofBytesWithCheck Fq2.findY
+def uncompressG1 : ByteArray → Option (Point Fq1) := uncompress 48 (by simp) Fq1.ofBytesWithCheck Fq1.findY
+def uncompressG2 : ByteArray → Option (Point Fq2) := uncompress 96 (by simp) Fq2.ofBytesWithCheck Fq2.findY
 
 end Internal
 

--- a/Cryptograph/BLS12_381/Basic.lean
+++ b/Cryptograph/BLS12_381/Basic.lean
@@ -364,7 +364,7 @@ def millerLoop (p : Point Fq1) (q : Point Fq2) (r : Point Fq2) (acc : Fq12) : Li
 /-- Calculates the value of the pairing (E) for point `p` and `q` without the final exponentiation.
     Implementation uses the canonical Miller loop. -/
 def calculateMillerLoop (p : Point Fq1) (q : Point Fq2) : Option Fq12 :=
-  millerLoop p q q 1 (List.tail! millerLoopIterBinary)
+  millerLoop p q q 1 (List.tail millerLoopIterBinary)
 
 /-- Tail-recursive implementation of the binary power. -/
 def binaryPowLoop {α} [Field α] (a acc : α) (n : Nat) : α :=
@@ -472,6 +472,14 @@ def i2ospN (n : Nat) (len : Nat) : ByteArray :=
     | 0     => acc
     | k + 1 => loop (UInt8.ofNat (n % 256) :: acc) (n / 256) k
   ⟨(loop [] n len).toArray⟩
+
+theorem i2ospN_loop_length (acc : List UInt8) (n len : Nat) : List.length (i2ospN.loop acc n len) = List.length acc + len := by
+  induction len generalizing acc n with
+  | zero       => simp [i2ospN.loop]
+  | succ n' ih => simp [i2ospN.loop, ih]; omega
+
+theorem i2ospN_length (n len : Nat) : ByteArray.size (i2ospN n len) = len := by
+  simp [i2ospN, ByteArray.size, i2ospN_loop_length]
 
 /- RFC9380: OS2IP function -/
 def os2ip (x : ByteArray) : Nat :=
@@ -780,11 +788,15 @@ def compressG1 : Point Fq1 → ByteArray
       -- result in `some y`.
       let y' := Option.getD (Fq1.findY x false) 0
       let b  := i2ospN x.t.val 48
-      let b0 := b[0]!
+      have h : b.size = 48 := i2ospN_length x.t.val 48
+      let b0 := b[0]
       let b' := b.extract 1 b.size
       if y ≤ y'
         then ⟨#[0b10000000 ||| b0]⟩ ++ b'
         else ⟨#[0b10100000 ||| b0]⟩ ++ b'
+
+theorem ByteArray.append_length (x y : ByteArray) : ByteArray.size (x ++ y) = x.size + y.size := by
+  simp [ByteArray.size, ByteArray.append, ByteArray.copySlice]
 
 def compressG2 : Point Fq2 → ByteArray
   | .infinity   => ⟨#[(0b11000000 : UInt8)] ++ Array.replicate 95 0⟩
@@ -793,16 +805,17 @@ def compressG2 : Point Fq2 → ByteArray
       -- result in `some y`.
       let y' := Option.getD (Fq2.findY x false) 0
       let b  := i2ospN x.u1.t.val 48 ++ i2ospN x.u0.t.val 48
-      let b0 := b[0]!
+      have h : b.size = 96 := by simp [b, i2ospN_length, ByteArray.append_length]
+      let b0 := getElem b 0 (by simp [h])
       let b' := b.extract 1 b.size
       if y ≤ y'
         then ⟨#[0b10000000 ||| b0]⟩ ++ b'
         else ⟨#[0b10100000 ||| b0]⟩ ++ b'
 
 def uncompress {α} [Field α] [DecidableEq α] (expectedLength : Nat) (_he : expectedLength > 0) (ofBytes : ByteArray → Option α) (findY : α → Bool → Option α) (b : ByteArray) : Option (Point α) :=
-  if b.size ≠ expectedLength
+  if h : b.size ≠ expectedLength
     then .none
-    else let b0   := b[0]!
+    else let b0   := b[0]
          let b₃₈₃ := decide (b0 &&& 0b10000000 > 0)
          let b₃₈₂ := decide (b0 &&& 0b01000000 > 0)
          let b₃₈₁ := decide (b0 &&& 0b00100000 > 0)

--- a/Cryptograph/BLS12_381/Basic.lean
+++ b/Cryptograph/BLS12_381/Basic.lean
@@ -496,11 +496,13 @@ def Fq1.sgn₀ (x : Fq1) : Fin 2 := ⟨x.t % 2, by omega⟩
 def sha256 (x : ByteArray) : ByteArray := Sha256.hashMessage x
 
 /-- Helper function to calculate running hashes of the message. -/
-def expandMessageXmdLoop (acc : ByteArray) (b₀ prev dst' : ByteArray) (ell i : Nat) : ByteArray :=
+def expandMessageXmdLoop (acc : List ByteArray) (totalLength : Nat) (b₀ prev dst' : ByteArray) (ell i : Nat) : ByteArray :=
   if i > ell
-    then acc
-    else let next := sha256 ((strxor b₀ prev) ++ ⟨#[i2osp₁ i]⟩ ++ dst')
-         expandMessageXmdLoop (acc ++ next) b₀ next dst' ell (i + 1)
+    then
+      List.foldl (· ++ ·) (.emptyWithCapacity totalLength) (List.reverse acc)
+    else
+      let next := sha256 ((strxor b₀ prev) ++ ⟨#[i2osp₁ i]⟩ ++ dst')
+      expandMessageXmdLoop (next :: acc) (totalLength + 8) b₀ next dst' ell (i + 1)
   termination_by (ell + 1 - i)
   decreasing_by omega
 
@@ -519,7 +521,7 @@ def expandMessageXmd (msg dst : ByteArray) (l : Nat) : Option ByteArray :=
       let msg'   := zPad ++ msg ++ libStr ++ ⟨#[i2osp₁ 0]⟩ ++ dst'
       let b₀     := sha256 msg'
       let b₁     := sha256 (b₀ ++ ⟨#[i2osp₁ 1]⟩ ++ dst')
-      let uBytes := b₁ ++ expandMessageXmdLoop .empty b₀ b₁ dst' ell 2
+      let uBytes := b₁ ++ expandMessageXmdLoop [] 0 b₀ b₁ dst' ell 2
       .some (uBytes.extract 0 l)
 
 /-- Hashes arbitrary-length byte strings to a pair of Fq1 values.

--- a/Cryptograph/BLS12_381/TestVectors.lean
+++ b/Cryptograph/BLS12_381/TestVectors.lean
@@ -83,31 +83,31 @@ example :
     | _          => false
   ) = true := by native_decide
 
-def testDst₁ := String.toByteList "QUUX-V01-CS02-with-expander-SHA256-128"
+def testDst₁ := String.toByteArray "QUUX-V01-CS02-with-expander-SHA256-128"
 
-example : (expandMessageXmd [] testDst₁ 0x20 |> Option.get! |> uint8ListToHex)
+example : (expandMessageXmd ByteArray.empty testDst₁ 0x20 |> Option.get! |> byteArrayToHex)
         = "68a985b87eb6b46952128911f2a4412bbc302a9d759667f87f7a21d803f07235" := by native_decide
-example : (expandMessageXmd (String.toByteList "abc") testDst₁ 0x20 |> Option.get! |> uint8ListToHex)
+example : (expandMessageXmd (String.toByteArray "abc") testDst₁ 0x20 |> Option.get! |> byteArrayToHex)
         = "d8ccab23b5985ccea865c6c97b6e5b8350e794e603b4b97902f53a8a0d605615" := by native_decide
-example : (expandMessageXmd (String.toByteList "abcdef0123456789") testDst₁ 0x20 |> Option.get! |> uint8ListToHex)
+example : (expandMessageXmd (String.toByteArray "abcdef0123456789") testDst₁ 0x20 |> Option.get! |> byteArrayToHex)
         = "eff31487c770a893cfb36f912fbfcbff40d5661771ca4b2cb4eafe524333f5c1" := by native_decide
-example : (expandMessageXmd (String.toByteList "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq") testDst₁ 0x20 |> Option.get! |> uint8ListToHex)
+example : (expandMessageXmd (String.toByteArray "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq") testDst₁ 0x20 |> Option.get! |> byteArrayToHex)
         = "b23a1d2b4d97b2ef7785562a7e8bac7eed54ed6e97e29aa51bfe3f12ddad1ff9" := by native_decide
-example : (expandMessageXmd (String.toByteList "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") testDst₁ 0x20 |> Option.get! |> uint8ListToHex)
+example : (expandMessageXmd (String.toByteArray "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") testDst₁ 0x20 |> Option.get! |> byteArrayToHex)
         = "4623227bcc01293b8c130bf771da8c298dede7383243dc0993d2d94823958c4c" := by native_decide
 
-example : (expandMessageXmd [] testDst₁ 0x80 |> Option.get! |> uint8ListToHex)
+example : (expandMessageXmd ByteArray.empty testDst₁ 0x80 |> Option.get! |> byteArrayToHex)
         = "af84c27ccfd45d41914fdff5df25293e221afc53d8ad2ac06d5e3e29485dadbee0d121587713a3e0dd4d5e69e93eb7cd4f5df4cd103e188cf60cb02edc3edf18eda8576c412b18ffb658e3dd6ec849469b979d444cf7b26911a08e63cf31f9dcc541708d3491184472c2c29bb749d4286b004ceb5ee6b9a7fa5b646c993f0ced" := by native_decide
-example : (expandMessageXmd (String.toByteList "abc") testDst₁ 0x80 |> Option.get! |> uint8ListToHex)
+example : (expandMessageXmd (String.toByteArray "abc") testDst₁ 0x80 |> Option.get! |> byteArrayToHex)
         = "abba86a6129e366fc877aab32fc4ffc70120d8996c88aee2fe4b32d6c7b6437a647e6c3163d40b76a73cf6a5674ef1d890f95b664ee0afa5359a5c4e07985635bbecbac65d747d3d2da7ec2b8221b17b0ca9dc8a1ac1c07ea6a1e60583e2cb00058e77b7b72a298425cd1b941ad4ec65e8afc50303a22c0f99b0509b4c895f40" := by native_decide
-example : (expandMessageXmd (String.toByteList "abcdef0123456789") testDst₁ 0x80 |> Option.get! |> uint8ListToHex)
+example : (expandMessageXmd (String.toByteArray "abcdef0123456789") testDst₁ 0x80 |> Option.get! |> byteArrayToHex)
         = "ef904a29bffc4cf9ee82832451c946ac3c8f8058ae97d8d629831a74c6572bd9ebd0df635cd1f208e2038e760c4994984ce73f0d55ea9f22af83ba4734569d4bc95e18350f740c07eef653cbb9f87910d833751825f0ebefa1abe5420bb52be14cf489b37fe1a72f7de2d10be453b2c9d9eb20c7e3f6edc5a60629178d9478df" := by native_decide
-example : (expandMessageXmd (String.toByteList "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq") testDst₁ 0x80 |> Option.get! |> uint8ListToHex)
+example : (expandMessageXmd (String.toByteArray "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq") testDst₁ 0x80 |> Option.get! |> byteArrayToHex)
         = "80be107d0884f0d881bb460322f0443d38bd222db8bd0b0a5312a6fedb49c1bbd88fd75d8b9a09486c60123dfa1d73c1cc3169761b17476d3c6b7cbbd727acd0e2c942f4dd96ae3da5de368d26b32286e32de7e5a8cb2949f866a0b80c58116b29fa7fabb3ea7d520ee603e0c25bcaf0b9a5e92ec6a1fe4e0391d1cdbce8c68a" := by native_decide
-example : (expandMessageXmd (String.toByteList "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") testDst₁ 0x80 |> Option.get! |> uint8ListToHex)
+example : (expandMessageXmd (String.toByteArray "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") testDst₁ 0x80 |> Option.get! |> byteArrayToHex)
         = "546aff5444b5b79aa6148bd81728704c32decb73a3ba76e9e75885cad9def1d06d6792f8a7d12794e90efed817d96920d728896a4510864370c207f99bd4a608ea121700ef01ed879745ee3e4ceef777eda6d9e5e38b90c86ea6fb0b36504ba4a45d22e86f6db5dd43d98a294bebb9125d5b794e9d2a81181066eb954966a487" := by native_decide
 
-def testDst₂ := String.toByteList "QUUX-V01-CS02-with-BLS12381G1_XMD:SHA-256_SSWU_RO_"
+def testDst₂ := String.toByteArray "QUUX-V01-CS02-with-BLS12381G1_XMD:SHA-256_SSWU_RO_"
 
 theorem fieldPrime_le_pow_2_381 : fieldPrime ≤ 2 ^ 381 := by decide +native
 
@@ -118,19 +118,19 @@ def Fq1.pointToHexString : Point Fq1 → String
       s!"{x'} {y'}"
   | .infinity   => "inf"
 
-example : (Fq1.hashToCurve [] testDst₂ |> Option.get! |> Fq1.pointToHexString)
+example : (Fq1.hashToCurve ByteArray.empty testDst₂ |> Option.get! |> Fq1.pointToHexString)
         = "052926add2207b76ca4fa57a8734416c8dc95e24501772c814278700eed6d1e4e8cf62d9c09db0fac349612b759e79a1 08ba738453bfed09cb546dbb0783dbb3a5f1f566ed67bb6be0e8c67e2e81a4cc68ee29813bb7994998f3eae0c9c6a265" := by native_decide
 
-example : (Fq1.hashToCurve (String.toByteList "abc") testDst₂ |> Option.get! |> Fq1.pointToHexString)
+example : (Fq1.hashToCurve (String.toByteArray "abc") testDst₂ |> Option.get! |> Fq1.pointToHexString)
         = "03567bc5ef9c690c2ab2ecdf6a96ef1c139cc0b2f284dca0a9a7943388a49a3aee664ba5379a7655d3c68900be2f6903 0b9c15f3fe6e5cf4211f346271d7b01c8f3b28be689c8429c85b67af215533311f0b8dfaaa154fa6b88176c229f2885d" := by native_decide
 
-example : (Fq1.hashToCurve (String.toByteList "abcdef0123456789") testDst₂ |> Option.get! |> Fq1.pointToHexString)
+example : (Fq1.hashToCurve (String.toByteArray "abcdef0123456789") testDst₂ |> Option.get! |> Fq1.pointToHexString)
         = "11e0b079dea29a68f0383ee94fed1b940995272407e3bb916bbf268c263ddd57a6a27200a784cbc248e84f357ce82d98 03a87ae2caf14e8ee52e51fa2ed8eefe80f02457004ba4d486d6aa1f517c0889501dc7413753f9599b099ebcbbd2d709" := by native_decide
 
-example : (Fq1.hashToCurve (String.toByteList "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq") testDst₂ |> Option.get! |> Fq1.pointToHexString)
+example : (Fq1.hashToCurve (String.toByteArray "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq") testDst₂ |> Option.get! |> Fq1.pointToHexString)
         = "15f68eaa693b95ccb85215dc65fa81038d69629f70aeee0d0f677cf22285e7bf58d7cb86eefe8f2e9bc3f8cb84fac488 1807a1d50c29f430b8cafc4f8638dfeeadf51211e1602a5f184443076715f91bb90a48ba1e370edce6ae1062f5e6dd38" := by native_decide
 
-example : (Fq1.hashToCurve (String.toByteList "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") testDst₂ |> Option.get! |> Fq1.pointToHexString)
+example : (Fq1.hashToCurve (String.toByteArray "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") testDst₂ |> Option.get! |> Fq1.pointToHexString)
         = "082aabae8b7dedb0e78aeb619ad3bfd9277a2f77ba7fad20ef6aabdc6c31d19ba5a6d12283553294c1825c4b3ca2dcfe 05b84ae5a942248eea39e1d91030458c40153f3b654ab7872d779ad1e942856a20c438e8d99bc8abfbf74729ce1f7ac8" := by native_decide
 
 def Fq2.pointToHexString : Point Fq2 → String
@@ -142,25 +142,25 @@ def Fq2.pointToHexString : Point Fq2 → String
       s!"{x₀} + I * {x₁}; {y₀} + I * {y₁}"
   | .infinity   => "inf"
 
-def testDst₃ := String.toByteList "QUUX-V01-CS02-with-BLS12381G2_XMD:SHA-256_SSWU_RO_"
+def testDst₃ := String.toByteArray "QUUX-V01-CS02-with-BLS12381G2_XMD:SHA-256_SSWU_RO_"
 
-example : (Fq2.hashToCurve [] testDst₃ |> Option.get! |> Fq2.pointToHexString)
+example : (Fq2.hashToCurve ByteArray.empty testDst₃ |> Option.get! |> Fq2.pointToHexString)
          = "0141ebfbdca40eb85b87142e130ab689c673cf60f1a3e98d69335266f30d9b8d4ac44c1038e9dcdd5393faf5c41fb78a + I * 05cb8437535e20ecffaef7752baddf98034139c38452458baeefab379ba13dff5bf5dd71b72418717047f5b0f37da03d; "
         ++ "0503921d7f6a12805e72940b963c0cf3471c7b2a524950ca195d11062ee75ec076daf2d4bc358c4b190c0c98064fdd92 + I * 12424ac32561493f3fe3c260708a12b7c620e7be00099a974e259ddc7d1f6395c3c811cdd19f1e8dbf3e9ecfdcbab8d6" := by native_decide
 
-example : (Fq2.hashToCurve (String.toByteList "abc") testDst₃ |> Option.get! |> Fq2.pointToHexString)
+example : (Fq2.hashToCurve (String.toByteArray "abc") testDst₃ |> Option.get! |> Fq2.pointToHexString)
          = "02c2d18e033b960562aae3cab37a27ce00d80ccd5ba4b7fe0e7a210245129dbec7780ccc7954725f4168aff2787776e6 + I * 139cddbccdc5e91b9623efd38c49f81a6f83f175e80b06fc374de9eb4b41dfe4ca3a230ed250fbe3a2acf73a41177fd8; "
         ++ "1787327b68159716a37440985269cf584bcb1e621d3a7202be6ea05c4cfe244aeb197642555a0645fb87bf7466b2ba48 + I * 00aa65dae3c8d732d10ecd2c50f8a1baf3001578f71c694e03866e9f3d49ac1e1ce70dd94a733534f106d4cec0eddd16" := by native_decide
 
-example : (Fq2.hashToCurve (String.toByteList "abcdef0123456789") testDst₃ |> Option.get! |> Fq2.pointToHexString)
+example : (Fq2.hashToCurve (String.toByteArray "abcdef0123456789") testDst₃ |> Option.get! |> Fq2.pointToHexString)
          = "121982811d2491fde9ba7ed31ef9ca474f0e1501297f68c298e9f4c0028add35aea8bb83d53c08cfc007c1e005723cd0 + I * 190d119345b94fbd15497bcba94ecf7db2cbfd1e1fe7da034d26cbba169fb3968288b3fafb265f9ebd380512a71c3f2c; "
         ++ "05571a0f8d3c08d094576981f4a3b8eda0a8e771fcdcc8ecceaf1356a6acf17574518acb506e435b639353c2e14827c8 + I * 0bb5e7572275c567462d91807de765611490205a941a5a6af3b1691bfe596c31225d3aabdf15faff860cb4ef17c7c3be" := by native_decide
 
-example : (Fq2.hashToCurve (String.toByteList "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq") testDst₃ |> Option.get! |> Fq2.pointToHexString)
+example : (Fq2.hashToCurve (String.toByteArray "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq") testDst₃ |> Option.get! |> Fq2.pointToHexString)
          = "19a84dd7248a1066f737cc34502ee5555bd3c19f2ecdb3c7d9e24dc65d4e25e50d83f0f77105e955d78f4762d33c17da + I * 0934aba516a52d8ae479939a91998299c76d39cc0c035cd18813bec433f587e2d7a4fef038260eef0cef4d02aae3eb91; "
         ++ "14f81cd421617428bc3b9fe25afbb751d934a00493524bc4e065635b0555084dd54679df1536101b2c979c0152d09192 + I * 09bcccfa036b4847c9950780733633f13619994394c23ff0b32fa6b795844f4a0673e20282d07bc69641cee04f5e5662" := by native_decide
 
-example : (Fq2.hashToCurve (String.toByteList "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") testDst₃ |> Option.get! |> Fq2.pointToHexString)
+example : (Fq2.hashToCurve (String.toByteArray "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") testDst₃ |> Option.get! |> Fq2.pointToHexString)
          = "01a6ba2f9a11fa5598b2d8ace0fbe0a0eacb65deceb476fbbcb64fd24557c2f4b18ecfc5663e54ae16a84f5ab7f62534 + I * 11fca2ff525572795a801eed17eb12785887c7b63fb77a42be46ce4a34131d71f7a73e95fee3f812aea3de78b4d01569; "
         ++ "0b6798718c8aed24bc19cb27f866f1c9effcdbf92397ad6448b5c9db90d2b9da6cbabf48adc1adf59a1a28344e79d57e + I * 03a47f8e6d1763ba0cad63d6114c0accbef65707825a511b251a660a9b3994249ae4e63fac38b23da0c398689ee2ab52" := by native_decide
 

--- a/Cryptograph/Blake2b/Blake2b.lean
+++ b/Cryptograph/Blake2b/Blake2b.lean
@@ -37,17 +37,17 @@ private def rotr64 (x : UInt64) (n : Nat) : UInt64 :=
   (x >>> n.toUInt64) ||| (x <<< (64 - n).toUInt64)
 
 -- Convert 8 bytes (little-endian) to UInt64
-private def bytesToUInt64LE (bytes : ByteArray) (offset : Nat) : UInt64 :=
-  let b0 := if offset + 0 < bytes.size then bytes[offset + 0]!.toUInt64 else 0
-  let b1 := if offset + 1 < bytes.size then bytes[offset + 1]!.toUInt64 else 0
-  let b2 := if offset + 2 < bytes.size then bytes[offset + 2]!.toUInt64 else 0
-  let b3 := if offset + 3 < bytes.size then bytes[offset + 3]!.toUInt64 else 0
-  let b4 := if offset + 4 < bytes.size then bytes[offset + 4]!.toUInt64 else 0
-  let b5 := if offset + 5 < bytes.size then bytes[offset + 5]!.toUInt64 else 0
-  let b6 := if offset + 6 < bytes.size then bytes[offset + 6]!.toUInt64 else 0
-  let b7 := if offset + 7 < bytes.size then bytes[offset + 7]!.toUInt64 else 0
-  b0 ||| (b1 <<< 8) ||| (b2 <<< 16) ||| (b3 <<< 24) |||
-  (b4 <<< 32) ||| (b5 <<< 40) ||| (b6 <<< 48) ||| (b7 <<< 56)
+private def bytesToUInt64LE (b : ByteArray) (offset : Nat) : UInt64 :=
+  let b₀ := if h₀ : offset + 0 < b.size then b[offset + 0].toUInt64 else 0
+  let b₁ := if h₁ : offset + 1 < b.size then b[offset + 1].toUInt64 else 0
+  let b₂ := if h₂ : offset + 2 < b.size then b[offset + 2].toUInt64 else 0
+  let b₃ := if h₃ : offset + 3 < b.size then b[offset + 3].toUInt64 else 0
+  let b₄ := if h₄ : offset + 4 < b.size then b[offset + 4].toUInt64 else 0
+  let b₅ := if h₅ : offset + 5 < b.size then b[offset + 5].toUInt64 else 0
+  let b₆ := if h₆ : offset + 6 < b.size then b[offset + 6].toUInt64 else 0
+  let b₇ := if h₇ : offset + 7 < b.size then b[offset + 7].toUInt64 else 0
+  b₀ ||| (b₁ <<<  8) ||| (b₂ <<< 16) ||| (b₃ <<< 24)
+     ||| (b₄ <<< 32) ||| (b₅ <<< 40) ||| (b₆ <<< 48) ||| (b₇ <<< 56)
 
 -- Convert UInt64 to 8 bytes (little-endian)
 private def uint64ToBytes (x : UInt64) : Array UInt8 :=
@@ -128,7 +128,7 @@ def blake2b (inputBytes : ByteArray) (outputLen : Nat) : ByteArray :=
     -- Initialize state with IV XOR parameter block
     -- Parameter block: digest_length || key_length || fanout || depth || ...
     let h := iv.map id  -- Copy IV
-    let h := h.set! 0 (h[0]! ^^^ 0x01010000 ^^^ outputLen.toUInt64)
+    let h := h.set 0 (h[0] ^^^ 0x01010000 ^^^ outputLen.toUInt64)
 
     -- Process full blocks
     let blockSize := 128  -- Blake2b block size in bytes

--- a/Cryptograph/Blake2b/Blake2b.lean
+++ b/Cryptograph/Blake2b/Blake2b.lean
@@ -7,6 +7,8 @@ namespace Cryptograph.Blake2b.Blake2b
 
 namespace Internal
 
+open Cryptograph.String
+
 -- Blake2b initialization vectors (first 64 bits of fractional parts of sqrt of first 8 primes)
 private def iv : Array UInt64 :=
   #[0x6a09e667f3bcc908, 0xbb67ae8584caa73b, 0x3c6ef372fe94f82b, 0xa54ff53a5f1d36f1,
@@ -85,15 +87,15 @@ private def g (v : Array UInt64) (a b c d : Nat) (x y : UInt64) : Array UInt64 :
 private def compress (h : Array UInt64) (m : Array UInt64) (t : UInt64) (f : Bool) : Array UInt64 :=
   -- Initialize working variables
   let v := Array.replicate 16 0
-  let v := (List.range 8).foldl (fun v i => v.set! i h[i]!) v
-  let v := (List.range 8).foldl (fun v i => v.set! (i + 8) iv[i]!) v
+  let v := (List.range 8).foldl (λ v i => v.set! i h[i]!) v
+  let v := (List.range 8).foldl (λ v i => v.set! (i + 8) iv[i]!) v
 
   -- Mix the counter and flag
   let v := v.set! 12 (v[12]! ^^^ t)
   let v := if f then v.set! 14 (~~~v[14]!) else v
 
   -- 12 rounds of mixing
-  let v := (List.range 12).foldl (fun v round =>
+  let v := (List.range 12).foldl (λ v round =>
     let s := sigma[round]!
     let v := g v 0 4  8 12 m[s[0]!]! m[s[1]!]!
     let v := g v 1 5  9 13 m[s[2]!]! m[s[3]!]!
@@ -107,21 +109,20 @@ private def compress (h : Array UInt64) (m : Array UInt64) (t : UInt64) (f : Boo
   ) v
 
   -- XOR the two halves
-  (List.range 8).foldl (fun h' i =>
+  (List.range 8).foldl (λ h' i =>
     h'.set! i (h'[i]! ^^^ v[i]! ^^^ v[i + 8]!)
   ) h
 
 -- Parse message block into 16 UInt64 values
 private def parseBlock (data : ByteArray) (offset : Nat) : Array UInt64 :=
-  Array.range 16 |>.map fun i => bytesToUInt64LE data (offset + i * 8)
+  (λ i => bytesToUInt64LE data (offset + i * 8)) <$> Array.range 16
 
 /-! ### Main Hash Function -/
 
 -- Blake2b hash with configurable output length
-def blake2b (input : List UInt8) (outputLen : Nat) : List UInt8 :=
-  if outputLen == 0 || outputLen > 64 then []
+def blake2b (inputBytes : ByteArray) (outputLen : Nat) : ByteArray :=
+  if outputLen == 0 || outputLen > 64 then .empty
   else
-    let inputBytes := ByteArray.mk input.toArray
     let inputLen := inputBytes.size
 
     -- Initialize state with IV XOR parameter block
@@ -132,7 +133,7 @@ def blake2b (input : List UInt8) (outputLen : Nat) : List UInt8 :=
     -- Process full blocks
     let blockSize := 128  -- Blake2b block size in bytes
     let numFullBlocks := (inputLen - 1) / blockSize
-    let h := (List.range numFullBlocks).foldl (fun h blockIdx =>
+    let h := (List.range numFullBlocks).foldl (λ h blockIdx =>
       let offset := blockIdx * blockSize
       let m := parseBlock inputBytes offset
       let t := ((blockIdx + 1) * blockSize).toUInt64
@@ -143,11 +144,11 @@ def blake2b (input : List UInt8) (outputLen : Nat) : List UInt8 :=
     let finalBlockStart := numFullBlocks * blockSize
     let finalBlockLen := inputLen - finalBlockStart
     let finalBlock := ByteArray.emptyWithCapacity 128
-    let finalBlock := (List.range finalBlockLen).foldl (fun arr i =>
+    let finalBlock := (List.range finalBlockLen).foldl (λ arr i =>
       arr.push inputBytes[finalBlockStart + i]!
     ) finalBlock
     -- Pad with zeros
-    let finalBlock := (List.range (blockSize - finalBlockLen)).foldl (fun arr _ =>
+    let finalBlock := (List.range (blockSize - finalBlockLen)).foldl (λ arr _ =>
       arr.push 0
     ) finalBlock
 
@@ -157,39 +158,35 @@ def blake2b (input : List UInt8) (outputLen : Nat) : List UInt8 :=
 
     -- Extract output bytes
     let output := ByteArray.emptyWithCapacity outputLen
-    let output := (List.range (outputLen / 8)).foldl (fun arr i =>
-      uint64ToBytes h[i]! |>.foldl (fun a b => a.push b) arr
+    let output := (List.range (outputLen / 8)).foldl (λ arr i =>
+      uint64ToBytes h[i]! |>.foldl (·.push) arr
     ) output
     -- Handle remaining bytes if output length is not multiple of 8
     let remainingBytes := outputLen % 8
     let output := if remainingBytes > 0 then
       let lastWord := uint64ToBytes h[outputLen / 8]!
-      (List.range remainingBytes).foldl (fun arr i =>
+      (List.range remainingBytes).foldl (λ arr i =>
         arr.push lastWord[i]!
       ) output
     else
       output
 
-    output.toList
+    output
 
 -- Blake2b-256: 256-bit (32-byte) output
-def blake2b_256 (input : List UInt8) : List UInt8 :=
+def blake2b_256 (input : ByteArray) : ByteArray :=
   blake2b input 32
 
 -- Blake2b-224: 224-bit (28-byte) output
-def blake2b_224 (input : List UInt8) : List UInt8 :=
+def blake2b_224 (input : ByteArray) : ByteArray :=
   blake2b input 28
 
 -- String versions
 def blake2b_256_hash (input : String) : String :=
-  let inputBytes := input.toUTF8.toList
-  let hashBytes := blake2b_256 inputBytes
-  Cryptograph.String.uint8ListToHex hashBytes
+  byteArrayToHex (blake2b_256 input.toUTF8)
 
 def blake2b_224_hash (input : String) : String :=
-  let inputBytes := input.toUTF8.toList
-  let hashBytes := blake2b_224 inputBytes
-  Cryptograph.String.uint8ListToHex hashBytes
+  byteArrayToHex (blake2b_224 input.toUTF8)
 
 end Internal
 

--- a/Cryptograph/Ed25519/Field.lean
+++ b/Cryptograph/Ed25519/Field.lean
@@ -104,6 +104,21 @@ def toBytesLE (a : Fp) : ByteArray :=
     else loop (acc.push (n % 256).toUInt8) (n / 256) (count - 1)
   loop ByteArray.empty a.val 32
 
+theorem ByteArray.push_length (b : ByteArray) (x : UInt8) : ByteArray.size (b.push x) = b.size + 1 := by
+  simp [ByteArray.push, ByteArray.size]
+
+theorem toBytesLE_loop_length (acc : ByteArray) (n count : Nat) : ByteArray.size (toBytesLE.loop acc n count) = acc.size + count := by
+  induction count generalizing acc n with
+  | zero          => simp [toBytesLE.loop]
+  | succ count ih =>
+      unfold toBytesLE.loop
+      simp [ih, ByteArray.push_length]
+      omega
+
+theorem toBytesLE_length (a : Fp) : ByteArray.size (toBytesLE a) = 32 := by
+  simp [toBytesLE]
+  apply toBytesLE_loop_length
+
 end Fp
 
 end Cryptograph.Ed25519.Field

--- a/Cryptograph/Ed25519/Field.lean
+++ b/Cryptograph/Ed25519/Field.lean
@@ -91,20 +91,18 @@ def div (a b : Fp) : Fp :=
 instance : Div Fp := ⟨div⟩
 
 -- Convert from bytes (little-endian, 32 bytes)
-def fromBytesLE (bytes : List UInt8) : Option Fp :=
-  let n := bytes.foldr (fun b acc => b.toNat + acc * 256) 0
+def fromBytesLE (bytes : ByteArray) : Option Fp :=
+  let n := (List.range bytes.size).foldr (λ i acc => bytes[i]!.toNat + acc * 256) 0
   if n < p
     then some ⟨n⟩
     else none
 
 -- Convert to bytes (little-endian, 32 bytes)
-partial def toBytesLE (a : Fp) : List UInt8 :=
-  let rec loop (n : Nat) (count : Nat) : List UInt8 :=
-    if count = 0 then []
-    else
-      let byte := (n % 256).toUInt8
-      byte :: loop (n / 256) (count - 1)
-  loop a.val 32
+def toBytesLE (a : Fp) : ByteArray :=
+  let rec loop (acc : ByteArray) (n : Nat) (count : Nat) : ByteArray :=
+    if count = 0 then acc
+    else loop (acc.push (n % 256).toUInt8) (n / 256) (count - 1)
+  loop ByteArray.empty a.val 32
 
 end Fp
 

--- a/Cryptograph/Ed25519/Point.lean
+++ b/Cryptograph/Ed25519/Point.lean
@@ -76,7 +76,7 @@ instance : HMul Nat EdPoint EdPoint := ⟨scalarMul⟩
 
 -- Scalar multiplication from bytes (little-endian)
 def scalarMulBytes (scalar : List UInt8) (p : EdPoint) : EdPoint :=
-  let n := scalar.foldr (fun b acc => b.toNat + acc * 256) 0
+  let n := scalar.foldr (λ b acc => b.toNat + acc * 256) 0
   scalarMul n p
 
 instance : HMul (List UInt8) EdPoint EdPoint := ⟨scalarMulBytes⟩
@@ -97,15 +97,15 @@ def basePoint : EdPoint :=
 
 -- Decompress a point from y-coordinate and sign bit
 -- Ed25519 uses point compression: only y and sign of x are stored
-def decompress (yBytes : List UInt8) : Option EdPoint :=
-  if yBytes.length ≠ 32 then none
+def decompress (yBytes : ByteArray) : Option EdPoint :=
+  if yBytes.size ≠ 32 then none
   else do
     -- Extract sign bit from last byte
     let lastByte := yBytes[31]!
     let xSign := lastByte >>> 7
 
     -- Clear sign bit to get y coordinate
-    let yBytes := yBytes.set 31 (lastByte &&& 0x7F)
+    let yBytes := yBytes.set! 31 (lastByte &&& 0x7F)
     let y      ← Fp.fromBytesLE yBytes
 
     -- Recover x from y using curve equation: x^2 = (y^2 - 1) / (d*y^2 + 1)
@@ -142,14 +142,13 @@ def curveOrder : Nat := 2^252 + 27742317777372353535851937790883648493
 def isInSubgroup (pt : EdPoint) : Bool := isZero (curveOrder * pt)
 
 -- Compress a point to 32 bytes (y-coordinate + sign bit)
-def compress (p : EdPoint) : List UInt8 :=
+def compress (p : EdPoint) : ByteArray :=
   let (x, y) := toAffine p
   let yBytes := Fp.toBytesLE y
   -- Set high bit of last byte to sign of x
   let lastByte := yBytes[31]!
   let xSign := if x.val % 2 = 0 then 0 else 0x80
-  let yBytes := yBytes.set 31 (lastByte ||| xSign)
-  yBytes
+  yBytes.set! 31 (lastByte ||| xSign)
 
 end EdPoint
 

--- a/Cryptograph/Ed25519/Point.lean
+++ b/Cryptograph/Ed25519/Point.lean
@@ -98,14 +98,14 @@ def basePoint : EdPoint :=
 -- Decompress a point from y-coordinate and sign bit
 -- Ed25519 uses point compression: only y and sign of x are stored
 def decompress (yBytes : ByteArray) : Option EdPoint :=
-  if yBytes.size ≠ 32 then none
+  if h : yBytes.size ≠ 32 then none
   else do
     -- Extract sign bit from last byte
-    let lastByte := yBytes[31]!
+    let lastByte := yBytes[31]
     let xSign := lastByte >>> 7
 
     -- Clear sign bit to get y coordinate
-    let yBytes := yBytes.set! 31 (lastByte &&& 0x7F)
+    let yBytes := yBytes.set 31 (lastByte &&& 0x7F)
     let y      ← Fp.fromBytesLE yBytes
 
     -- Recover x from y using curve equation: x^2 = (y^2 - 1) / (d*y^2 + 1)
@@ -145,10 +145,11 @@ def isInSubgroup (pt : EdPoint) : Bool := isZero (curveOrder * pt)
 def compress (p : EdPoint) : ByteArray :=
   let (x, y) := toAffine p
   let yBytes := Fp.toBytesLE y
+  have hyb   :  yBytes.size = 32 := Fp.toBytesLE_length y
   -- Set high bit of last byte to sign of x
-  let lastByte := yBytes[31]!
+  let lastByte := yBytes[31]
   let xSign := if x.val % 2 = 0 then 0 else 0x80
-  yBytes.set! 31 (lastByte ||| xSign)
+  yBytes.set 31 (lastByte ||| xSign)
 
 end EdPoint
 

--- a/Cryptograph/Ed25519/Signature.lean
+++ b/Cryptograph/Ed25519/Signature.lean
@@ -11,23 +11,23 @@ open Cryptograph.Ed25519.Field
 open Cryptograph.Sha2.Sha512
 
 -- Convert bytes (little-endian) to Nat
-def bytesToNat (bytes : List UInt8) : Nat :=
-  bytes.foldr (fun b acc => b.toNat + acc * 256) 0
+def bytesToNat (bytes : ByteArray) : Nat :=
+  (List.range bytes.size).foldr (λ i acc => bytes[i]!.toNat + acc * 256) 0
 
 -- Reduce a 512-bit hash to a scalar modulo L (little-endian bytes)
-def reduceModL (hash : List UInt8) : Nat :=
+def reduceModL (hash : ByteArray) : Nat :=
   bytesToNat hash % curveOrder
 
 -- Verify Ed25519 signature
 -- Returns true if signature is valid
-def verify (publicKey : List UInt8) (message : List UInt8) (signature : List UInt8) : Bool :=
+def verify (publicKey : ByteArray) (message : ByteArray) (signature : ByteArray) : Bool :=
   -- Check lengths
-  if publicKey.length != 32 then false
-  else if signature.length != 64 then false
+  if publicKey.size != 32 then false
+  else if signature.size != 64 then false
   else
     -- Split signature into R (32 bytes) and s (32 bytes)
-    let rBytes := signature.take 32
-    let sBytes := signature.drop 32
+    let rBytes := signature.extract 0 32
+    let sBytes := signature.extract 32 64
 
     -- Decode public key A
     match EdPoint.decompress publicKey with
@@ -44,9 +44,8 @@ def verify (publicKey : List UInt8) (message : List UInt8) (signature : List UIn
         if Nat.ble curveOrder s then false
         else
           -- Compute hash: h = SHA-512(R || A || M)
-          let hashInput  := rBytes ++ publicKey ++ message
-          let hashOutput := Internal.hashMessage hashInput
-          let hashBytes  := hashOutput.flatMap Cryptograph.Integer.UInt64.toUInt8BE
+          let hashInput := rBytes ++ publicKey ++ message
+          let hashBytes := Internal.hashMessage hashInput
 
           -- Reduce hash modulo L
           let h := reduceModL hashBytes

--- a/Cryptograph/Integer/Basic.lean
+++ b/Cryptograph/Integer/Basic.lean
@@ -2,22 +2,27 @@ namespace Cryptograph.Integer
 
 namespace Internal
 
-def UInt32.toUInt8BE (x : UInt32) : List UInt8 :=
+def UInt32.toUInt8BE (x : UInt32) : ByteArray :=
   let x₀ := x
   let x₁ := x₀ >>> 8
   let x₂ := x₁ >>> 8
   let x₃ := x₂ >>> 8
-  [ UInt32.toUInt8 x₃, UInt32.toUInt8 x₂, UInt32.toUInt8 x₁, UInt32.toUInt8 x₀ ]
+  ⟨#[ UInt32.toUInt8 x₃, UInt32.toUInt8 x₂, UInt32.toUInt8 x₁, UInt32.toUInt8 x₀ ]⟩
 
-def UInt64.toUInt8BE (x : UInt64) : List UInt8 :=
+def UInt64.toUInt8BE (x : UInt64) : ByteArray :=
   let x₁ := x >>> 32
   UInt32.toUInt8BE (UInt64.toUInt32 x₁) ++ UInt32.toUInt8BE (UInt64.toUInt32 x)
 
-def UInt128.toUInt8BE (n : Nat) : List UInt8 :=
+def UInt128.toUInt8BE (n : Nat) : ByteArray :=
   UInt64.toUInt8BE (n >>> 64).toUInt64 ++ UInt64.toUInt8BE n.toUInt64
 
-def UInt32.ofUInt8BE (x : Vector UInt8 4) : UInt32 :=
-  (UInt8.toUInt32 x[0]) <<< 24 ||| (UInt8.toUInt32 x[1]) <<< 16 ||| (UInt8.toUInt32 x[2]) <<< 8 ||| UInt8.toUInt32 x[3]
+/-- Read 4 bytes from a `ByteArray` starting at offset `i` as a big-endian `UInt32`.
+    Out-of-bounds reads return `0` for the missing bytes (matching `ByteArray.get!`). -/
+def UInt32.ofUInt8BE (b : ByteArray) (i : Nat := 0) : UInt32 :=
+  (UInt8.toUInt32 (b.get!  i     )) <<< 24 |||
+  (UInt8.toUInt32 (b.get! (i + 1))) <<< 16 |||
+  (UInt8.toUInt32 (b.get! (i + 2))) <<<  8 |||
+   UInt8.toUInt32 (b.get! (i + 3))
 
 def rotr (n : Fin 32) (x : UInt32) : UInt32 := let n' := UInt32.ofNat n; x >>> n' ||| x <<< (32 - n')
 def shr  (n : Fin 32) (x : UInt32) : UInt32 := let n' := UInt32.ofNat n; x >>> n'

--- a/Cryptograph/Keccak/Keccak256.lean
+++ b/Cryptograph/Keccak/Keccak256.lean
@@ -7,24 +7,26 @@ namespace Cryptograph.Keccak.Keccak256
 
 namespace Internal
 
+open Cryptograph.String
+
 -- Type aliases
-private abbrev Lane := UInt64
+private abbrev Lane  := UInt64
 private abbrev State := Array (Array Lane)
 
 -- Constants
-private def stateWidth : Nat := 5
-private def rounds : Nat := 24
-private def rate : Nat := 136          -- 1088 bits for Keccak-256
-private def capacity : Nat := 64       -- 512 bits
-private def outputLength : Nat := 32   -- 256 bits
+private def stateWidth   : Nat :=   5
+private def rounds       : Nat :=  24
+private def rate         : Nat := 136   -- 1088 bits for Keccak-256
+private def capacity     : Nat :=  64   -- 512 bits
+private def outputLength : Nat :=  32   -- 256 bits
 
 -- Rotation offsets for ρ (rho) step
 private def rotationOffsets : Array (Array Nat) :=
-  #[#[0, 1, 62, 28, 27],
-    #[36, 44, 6, 55, 20],
-    #[3, 10, 43, 25, 39],
-    #[41, 45, 15, 21, 8],
-    #[18, 2, 61, 56, 14]]
+  #[#[ 0,  1, 62, 28, 27],
+    #[36, 44,  6, 55, 20],
+    #[ 3, 10, 43, 25, 39],
+    #[41, 45, 15, 21,  8],
+    #[18,  2, 61, 56, 14]]
 
 -- Round constants for ι (iota) step
 private def roundConstants : Array UInt64 :=
@@ -199,20 +201,16 @@ private def squeeze (state : State) (outputLen : Nat) : ByteArray :=
 /-! ### Main Hash Function -/
 
 -- Keccak-256 hash function
--- Takes a list of bytes and returns 32-byte hash
-def hashBytes (input : List UInt8) : List UInt8 :=
-  let inputBytes := ByteArray.mk input.toArray
-  let padded := pad inputBytes
-  let state := absorb initState padded
-  let outputBytes := squeeze state outputLength
-  outputBytes.toList
+-- Takes a ByteArray and returns a 32-byte ByteArray hash
+def hashBytes (input : ByteArray) : ByteArray :=
+  let padded := pad input
+  let state  := absorb initState padded
+  squeeze state outputLength
 
 -- Keccak-256 hash function for strings
 -- Takes a string and returns hex-encoded hash
 def hash (input : String) : String :=
-  let inputBytes := input.toUTF8.toList
-  let hashBytes := hashBytes inputBytes
-  Cryptograph.String.uint8ListToHex hashBytes
+  byteArrayToHex (hashBytes input.toUTF8)
 
 /-! ### SHA3-256 Hash Function
 
@@ -221,20 +219,16 @@ but with a different padding suffix (0x06 instead of 0x01).
 -/
 
 -- SHA3-256 hash function
--- Takes a list of bytes and returns 32-byte hash
-def sha3_256_hashBytes (input : List UInt8) : List UInt8 :=
-  let inputBytes := ByteArray.mk input.toArray
-  let padded := pad inputBytes 0x06  -- SHA3 domain separation
-  let state := absorb initState padded
-  let outputBytes := squeeze state outputLength
-  outputBytes.toList
+-- Takes a ByteArray and returns a 32-byte ByteArray hash
+def sha3_256_hashBytes (input : ByteArray) : ByteArray :=
+  let padded := pad input 0x06  -- SHA3 domain separation
+  let state  := absorb initState padded
+  squeeze state outputLength
 
 -- SHA3-256 hash function for strings
 -- Takes a string and returns hex-encoded hash
 def sha3_256_hash (input : String) : String :=
-  let inputBytes := input.toUTF8.toList
-  let hashBytes := sha3_256_hashBytes inputBytes
-  Cryptograph.String.uint8ListToHex hashBytes
+  byteArrayToHex (sha3_256_hashBytes input.toUTF8)
 
 end Internal
 

--- a/Cryptograph/Ripemd/Ripemd160.lean
+++ b/Cryptograph/Ripemd/Ripemd160.lean
@@ -8,6 +8,7 @@ namespace Cryptograph.Ripemd.Ripemd160
 namespace Internal
 
 open Cryptograph.Integer
+open Cryptograph.String
 
 -- Initial hash values
 private def h0 : UInt32 := 0x67452301
@@ -185,9 +186,8 @@ private def parseBlock (data : ByteArray) (offset : Nat) : Array UInt32 :=
 /-! ### Main Hash Function -/
 
 -- RIPEMD-160 hash function
-def ripemd160 (input : List UInt8) : List UInt8 :=
-  let inputBytes := ByteArray.mk input.toArray
-  let padded := padMessage inputBytes
+def ripemd160 (input : ByteArray) : ByteArray :=
+  let padded := padMessage input
 
   -- Initialize hash state
   let h := #[h0, h1, h2, h3, h4]
@@ -201,17 +201,13 @@ def ripemd160 (input : List UInt8) : List UInt8 :=
   ) h
 
   -- Convert hash state to bytes (little-endian)
-  let output := h.foldl (fun arr word =>
+  h.foldl (fun arr word =>
     uint32ToBytes word |>.foldl (fun a b => a.push b) arr
   ) ByteArray.empty
 
-  output.toList
-
 -- String version
 def ripemd160_hash (input : String) : String :=
-  let inputBytes := input.toUTF8.toList
-  let hashBytes := ripemd160 inputBytes
-  Cryptograph.String.uint8ListToHex hashBytes
+  byteArrayToHex (ripemd160 input.toUTF8)
 
 end Internal
 

--- a/Cryptograph/Secp256k1/ECDSA.lean
+++ b/Cryptograph/Secp256k1/ECDSA.lean
@@ -61,7 +61,7 @@ def verify (publicKey : ByteArray) (message : ByteArray) (signature : ByteArray)
   if signature.size != 64 then false
   else
     -- Parse signature: r (32 bytes) || s (32 bytes)
-    let rBytes := signature.extract 0 32
+    let rBytes := signature.extract  0 32
     let sBytes := signature.extract 32 64
     let r := bytesToNat rBytes
     let s := bytesToNat sBytes
@@ -76,9 +76,9 @@ def verify (publicKey : ByteArray) (message : ByteArray) (signature : ByteArray)
       match Secp256k1Point.decompress publicKey with
       | none =>
         -- Try uncompressed format (0x04 || x || y)
-        if publicKey.size != 65 || publicKey[0]! != 0x04 then false
+        if publicKey.size != 65 || publicKey[0]? != some 0x04 then false
         else Option.getD (do
-          let xBytes := publicKey.extract 1 33
+          let xBytes := publicKey.extract  1 33
           let yBytes := publicKey.extract 33 65
           let x      ← Fp.fromBytesBE xBytes
           let y      ← Fp.fromBytesBE yBytes

--- a/Cryptograph/Secp256k1/ECDSA.lean
+++ b/Cryptograph/Secp256k1/ECDSA.lean
@@ -26,12 +26,12 @@ def invModN (a : Nat) : Nat :=
   powModN a (curveOrder - 2)
 
 -- Convert bytes (big-endian) to Nat
-def bytesToNat (bytes : List UInt8) : Nat :=
-  bytes.foldl (fun acc b => acc * 256 + b.toNat) 0
+def bytesToNat (bytes : ByteArray) : Nat :=
+  bytes.foldl (λ acc b => acc * 256 + b.toNat) 0
 
 -- Helper: verify with parsed point
-def verifyWithPoint (q : Secp256k1Point) (r s : Nat) (message : List UInt8) : Bool :=
-  if (message.length != 32) || (s == 0)
+def verifyWithPoint (q : Secp256k1Point) (r s : Nat) (message : ByteArray) : Bool :=
+  if (message.size != 32) || (s == 0)
     then false
     else
       let h := bytesToNat message
@@ -56,13 +56,13 @@ def verifyWithPoint (q : Secp256k1Point) (r s : Nat) (message : List UInt8) : Bo
         (x.val % curveOrder) == r
 
 -- Verify ECDSA signature
-def verify (publicKey : List UInt8) (message : List UInt8) (signature : List UInt8) : Bool :=
+def verify (publicKey : ByteArray) (message : ByteArray) (signature : ByteArray) : Bool :=
   -- Check signature length
-  if signature.length != 64 then false
+  if signature.size != 64 then false
   else
     -- Parse signature: r (32 bytes) || s (32 bytes)
-    let rBytes := signature.take 32
-    let sBytes := signature.drop 32
+    let rBytes := signature.extract 0 32
+    let sBytes := signature.extract 32 64
     let r := bytesToNat rBytes
     let s := bytesToNat sBytes
 
@@ -76,10 +76,10 @@ def verify (publicKey : List UInt8) (message : List UInt8) (signature : List UIn
       match Secp256k1Point.decompress publicKey with
       | none =>
         -- Try uncompressed format (0x04 || x || y)
-        if publicKey.length != 65 || publicKey[0]! != 0x04 then false
+        if publicKey.size != 65 || publicKey[0]! != 0x04 then false
         else Option.getD (do
-          let xBytes := publicKey.toArray[1:33].toList
-          let yBytes := publicKey.toArray[33:65].toList
+          let xBytes := publicKey.extract 1 33
+          let yBytes := publicKey.extract 33 65
           let x      ← Fp.fromBytesBE xBytes
           let y      ← Fp.fromBytesBE yBytes
           guard (Secp256k1Point.isOnCurve x y)

--- a/Cryptograph/Secp256k1/Field.lean
+++ b/Cryptograph/Secp256k1/Field.lean
@@ -90,20 +90,18 @@ def div (a b : Fp) : Fp :=
 instance : Div Fp := ⟨div⟩
 
 -- Convert from bytes (big-endian, 32 bytes)
-def fromBytesBE (bytes : List UInt8) : Option Fp :=
+def fromBytesBE (bytes : ByteArray) : Option Fp :=
   let n := bytes.foldl (fun acc b => acc * 256 + b.toNat) 0
   if n < p
     then some (ofNat n)
     else none
 
 -- Convert to bytes (big-endian, 32 bytes)
-partial def toBytesBE (a : Fp) : List UInt8 :=
-  let rec loop (n : Nat) (count : Nat) : List UInt8 :=
-    if count = 0 then []
-    else
-      let byte := (n % 256).toUInt8
-      loop (n / 256) (count - 1) ++ [byte]
-  loop a.val 32
+def toBytesBE (a : Fp) : ByteArray :=
+  let rec loop (acc : List UInt8) (n : Nat) (count : Nat) : List UInt8 :=
+    if count = 0 then acc
+    else loop ((n % 256).toUInt8 :: acc) (n / 256) (count - 1)
+  ⟨(loop [] a.val 32).toArray⟩
 
 end Fp
 

--- a/Cryptograph/Secp256k1/Point.lean
+++ b/Cryptograph/Secp256k1/Point.lean
@@ -119,11 +119,11 @@ def basePoint : Secp256k1Point :=
 def isOnCurve (x y : Fp) : Bool := y^2 == x^3 + 7
 
 -- Decompress a point from x-coordinate and sign bit (SEC1 encoding)
-def decompress (bytes : List UInt8) : Option Secp256k1Point :=
-  if h : bytes.length ≠ 33 then none
+def decompress (bytes : ByteArray) : Option Secp256k1Point :=
+  if h : bytes.size ≠ 33 then none
   else
-    let prefixByte := bytes.head (by grind only [= List.length_nil])
-    let xBytes     := bytes.tail
+    let prefixByte := bytes[0]
+    let xBytes     := bytes.extract 1 33
     let xOpt       := Fp.fromBytesBE xBytes
     match prefixByte == 0x02 || prefixByte == 0x03, xOpt with
     | true, some x =>
@@ -144,13 +144,13 @@ def decompress (bytes : List UInt8) : Option Secp256k1Point :=
     | _, _ => none
 
 -- Compress a point to 33 bytes (prefix byte + x-coordinate)
-def compress (p : Secp256k1Point) : Option (List UInt8) :=
+def compress (p : Secp256k1Point) : Option ByteArray :=
   match toAffine p with
   | none => none
   | some (x, y) =>
-    let prefixByte := if y.val % 2 = 0 then 0x02 else 0x03
+    let prefixByte : UInt8 := if y.val % 2 = 0 then 0x02 else 0x03
     let xBytes := Fp.toBytesBE x
-    some (prefixByte :: xBytes)
+    some (ByteArray.mk #[prefixByte] ++ xBytes)
 
 end Secp256k1Point
 

--- a/Cryptograph/Secp256k1/Schnorr.lean
+++ b/Cryptograph/Secp256k1/Schnorr.lean
@@ -13,32 +13,18 @@ open Cryptograph.Sha2.Sha256
 def curveOrder : Nat := 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
 
 -- Convert bytes (big-endian) to Nat
-def bytesToNat (bytes : List UInt8) : Nat :=
+def bytesToNat (bytes : ByteArray) : Nat :=
   bytes.foldl (fun acc b => acc * 256 + b.toNat) 0
 
--- Convert Nat to 32 bytes (big-endian)
-partial def natToBytes32 (n : Nat) : List UInt8 :=
-  let rec loop (n : Nat) (count : Nat) : List UInt8 :=
-    if count = 0 then []
-    else
-      let byte := (n % 256).toUInt8
-      loop (n / 256) (count - 1) ++ [byte]
-  loop n 32
-
 -- BIP-340 tagged hash: SHA256(SHA256(tag) || SHA256(tag) || msg)
-def taggedHash (tag : String) (msg : List UInt8) : List UInt8 :=
-  let tagBytes := tag.toUTF8.toList
-  let tagHashVec := hashMessage tagBytes
-  let tagHash := Vector.toList tagHashVec |>.flatMap Cryptograph.Integer.UInt32.toUInt8BE
-
+def taggedHash (tag : String) (msg : ByteArray) : ByteArray :=
+  let tagHash := hashMessage tag.toUTF8
   -- Double the tag hash and append message
-  let input := tagHash ++ tagHash ++ msg
-  let hashVec := hashMessage input
-  Vector.toList hashVec |>.flatMap Cryptograph.Integer.UInt32.toUInt8BE
+  hashMessage (tagHash ++ tagHash ++ msg)
 
 -- Lift x-coordinate to point (assumes even y)
-def liftX (xBytes : List UInt8) : Option Secp256k1Point :=
-  if xBytes.length ≠ 32 then none
+def liftX (xBytes : ByteArray) : Option Secp256k1Point :=
+  if xBytes.size ≠ 32 then none
   else
     -- BIP-340: reject if x ≥ p (raw integer must be a valid field element)
     let xNat := bytesToNat xBytes
@@ -66,14 +52,14 @@ def hasEvenY (p : Secp256k1Point) : Bool :=
   | some (_, y) => y.val % 2 == 0
 
 -- Verify BIP-340 Schnorr signature
-def verify (publicKey : List UInt8) (message : List UInt8) (signature : List UInt8) : Bool :=
+def verify (publicKey : ByteArray) (message : ByteArray) (signature : ByteArray) : Bool :=
   -- Check lengths
-  if publicKey.length ≠ 32 then false
-  else if signature.length ≠ 64 then false
+  if publicKey.size ≠ 32 then false
+  else if signature.size ≠ 64 then false
   else
     -- Parse signature: r (32 bytes) || s (32 bytes)
-    let rBytes := signature.take 32
-    let sBytes := signature.drop 32
+    let rBytes := signature.extract 0 32
+    let sBytes := signature.extract 32 64
     let r := bytesToNat rBytes
     let s := bytesToNat sBytes
 

--- a/Cryptograph/Sha2/Sha256.lean
+++ b/Cryptograph/Sha2/Sha256.lean
@@ -19,22 +19,27 @@ def k : Vector UInt32 64 :=
     , 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
     ]
 
-def List.pairs {α} (x : List α) : List (α × α) :=
-  let rec loop (acc : List (α × α)) : List α → List (α × α)
-    | h₁ :: h₂ :: t => loop ((h₁, h₂) :: acc) t
-    | _             => List.reverse acc
-  loop [] x
+/-- Pack the 64 bytes of `b` starting at `start` into 16 big-endian `UInt32`s.
+    Caller must ensure `start + 64 ≤ b.size`. -/
+def chunkToWords (b : ByteArray) (start : Nat) : Vector UInt32 16 :=
+  #v[ UInt32.ofUInt8BE b (start +  0), UInt32.ofUInt8BE b (start +  4)
+    , UInt32.ofUInt8BE b (start +  8), UInt32.ofUInt8BE b (start + 12)
+    , UInt32.ofUInt8BE b (start + 16), UInt32.ofUInt8BE b (start + 20)
+    , UInt32.ofUInt8BE b (start + 24), UInt32.ofUInt8BE b (start + 28)
+    , UInt32.ofUInt8BE b (start + 32), UInt32.ofUInt8BE b (start + 36)
+    , UInt32.ofUInt8BE b (start + 40), UInt32.ofUInt8BE b (start + 44)
+    , UInt32.ofUInt8BE b (start + 48), UInt32.ofUInt8BE b (start + 52)
+    , UInt32.ofUInt8BE b (start + 56), UInt32.ofUInt8BE b (start + 60) ]
 
-def UInt32.listOfUInt8 (x : List UInt8) : List UInt32 :=
-  List.map (λ ((b₀, b₁), b₂, b₃) => UInt32.ofUInt8BE #v[b₀, b₁, b₂, b₃]) (List.pairs (List.pairs x))
-
-def padMessage (x : List UInt8) : List UInt8 :=
-  let l      := List.length x
+/-- Pad the message to a multiple of 64 bytes:
+    append `0x80`, then enough `0x00` bytes, then the original length-in-bits as a 64-bit BE int. -/
+def padMessage (x : ByteArray) : ByteArray :=
+  let l      := x.size
   let padn   := (120 - ((l + 1) % 64)) % 64
-  let zeroes := List.replicate padn 0x00
+  let zeroes := ⟨Array.replicate padn 0x00⟩
   if l ≥ 2 ^ 61
     then panic! "Message too long!"
-    else x ++ (0x80 :: zeroes) ++ UInt64.toUInt8BE (UInt64.ofNat (l * 8))
+    else x ++ ⟨#[0x80]⟩ ++ zeroes ++ UInt64.toUInt8BE (UInt64.ofNat (l * 8))
 
 def σ₀ (x : UInt32) : UInt32 := rotr  7 x ^^^ rotr 18 x ^^^ shr  3 x
 def σ₁ (x : UInt32) : UInt32 := rotr 17 x ^^^ rotr 19 x ^^^ shr 10 x
@@ -62,31 +67,32 @@ def hashLoop (m : Vector UInt32 16) (v : Vector UInt32 8) (t : Fin 64) : Vector 
     else v'
   termination_by (63 - t)
 
-def processChunks (v : Vector UInt32 8) (x : List UInt8) : Vector UInt32 8 :=
-  if List.length x = 0
+/-- Process `x` 64 bytes at a time starting from byte index `i`. Caller must ensure
+    `x.size` is a multiple of 64 and `i ≤ x.size`. -/
+def processChunks (v : Vector UInt32 8) (x : ByteArray) (i : Nat) : Vector UInt32 8 :=
+  if h : i ≥ x.size
     then v
     else
-      let x'    := List.drop 64 x
-      let chunk := List.toArray (UInt32.listOfUInt8 (List.take 64 x))
-      if harray_size : Array.size chunk = 16
-        then let m  := Vector.mk chunk harray_size
-             let h  := hashLoop m v 0
-             let v' := h + v
-             processChunks v' x'
-        else unreachable!
-  termination_by (List.length x)
-  decreasing_by simp; omega
+      let m  := chunkToWords x i
+      let h' := hashLoop m v 0
+      let v' := h' + v
+      processChunks v' x (i + 64)
+  termination_by (x.size - i)
+  decreasing_by simp_wf; simp at h; omega
 
 def initial : Vector UInt32 8 := #v[ 0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19 ]
 
-def hashMessage (x : List UInt8) : Vector UInt32 8 :=
+/-- Pack 8 `UInt32`s into a 32-byte big-endian `ByteArray`. -/
+def wordsToBytes (v : Vector UInt32 8) : ByteArray :=
+  UInt32.toUInt8BE v[0] ++ UInt32.toUInt8BE v[1] ++ UInt32.toUInt8BE v[2] ++ UInt32.toUInt8BE v[3] ++
+  UInt32.toUInt8BE v[4] ++ UInt32.toUInt8BE v[5] ++ UInt32.toUInt8BE v[6] ++ UInt32.toUInt8BE v[7]
+
+def hashMessage (x : ByteArray) : ByteArray :=
   let padded := padMessage x
-  processChunks initial padded
+  wordsToBytes (processChunks initial padded 0)
 
 def hash (x : String) : String :=
-  let message := String.toByteList x
-  let hashed  := hashMessage message
-  uint32ListToHex (Vector.toList hashed)
+  byteArrayToHex (hashMessage x.toByteArray)
 
 end Internal
 

--- a/Cryptograph/Sha2/Sha512.lean
+++ b/Cryptograph/Sha2/Sha512.lean
@@ -59,7 +59,7 @@ def Maj (x y z : UInt64) : UInt64 := (x &&& y) ^^^ (x &&& z) ^^^ (y &&& z)
 
 -- Convert 8 bytes (big-endian) to UInt64. Out-of-bounds reads contribute 0.
 def bytesToUInt64BE (bytes : ByteArray) (offset : Nat) : UInt64 :=
-  let get := fun i => if offset + i < bytes.size then bytes[offset + i]!.toUInt64 else 0
+  let get := λ i => if h : offset + i < bytes.size then bytes[offset + i].toUInt64 else 0
   (get 0 <<< 56) ||| (get 1 <<< 48) ||| (get 2 <<< 40) ||| (get 3 <<< 32) |||
   (get 4 <<< 24) ||| (get 5 <<< 16) ||| (get 6 <<<  8) |||  get 7
 
@@ -75,10 +75,10 @@ def padMessage (x : ByteArray) : ByteArray :=
 -- Process one 1024-bit chunk (128 bytes starting at `offset` in `x`)
 def processChunk (h : List UInt64) (x : ByteArray) (offset : Nat) : List UInt64 :=
   -- Parse chunk into 16 UInt64 words
-  let w0 := List.range 16 |>.map (fun i => bytesToUInt64BE x (offset + i * 8))
+  let w0 := List.range 16 |>.map (λ i => bytesToUInt64BE x (offset + i * 8))
 
   -- Extend to 80 words
-  let w := (List.range 64).foldl (fun w i =>
+  let w := (List.range 64).foldl (λ w i =>
     let w16 := w[i]!
     let w15 := w[i + 1]!
     let w7 := w[i + 9]!
@@ -97,7 +97,7 @@ def processChunk (h : List UInt64) (x : ByteArray) (offset : Nat) : List UInt64 
   let h₀ := h[7]!
 
   -- 80 rounds
-  let (a, b, c, d, e, f, g, h₀) := (List.range 80).zip (w.zip k) |>.foldl (fun (a, b, c, d, e, f, g, h) (_, (wi, ki)) =>
+  let (a, b, c, d, e, f, g, h₀) := (List.range 80).zip (w.zip k) |>.foldl (λ (a, b, c, d, e, f, g, h) (_, (wi, ki)) =>
     let T1 := h + bigSigma1 e + Ch e f g + ki + wi
     let T2 := bigSigma0 a + Maj a b c
     (T1 + T2, a, b, c, d + T1, e, f, g)
@@ -118,7 +118,7 @@ decreasing_by simp_wf; omega
 
 -- Pack the 8 final UInt64 hash values into a 64-byte ByteArray (big-endian)
 def wordsToBytes (h : List UInt64) : ByteArray :=
-  h.foldl (fun acc w => acc ++ UInt64.toUInt8BE w) ByteArray.empty
+  h.foldl (λ acc w => acc ++ UInt64.toUInt8BE w) ByteArray.empty
 
 -- Main hash function
 def hashMessage (x : ByteArray) : ByteArray :=

--- a/Cryptograph/Sha2/Sha512.lean
+++ b/Cryptograph/Sha2/Sha512.lean
@@ -57,25 +57,25 @@ def sigma1 (x : UInt64) : UInt64 := rotr64 19 x ^^^ rotr64 61 x ^^^ shr64 6 x
 def Ch (x y z : UInt64) : UInt64 := (x &&& y) ^^^ (~~~x &&& z)
 def Maj (x y z : UInt64) : UInt64 := (x &&& y) ^^^ (x &&& z) ^^^ (y &&& z)
 
--- Convert 8 bytes (big-endian) to UInt64
-def bytesToUInt64BE (bytes : List UInt8) (offset : Nat) : UInt64 :=
-  let get := fun i => if offset + i < bytes.length then bytes[offset + i]!.toUInt64 else 0
+-- Convert 8 bytes (big-endian) to UInt64. Out-of-bounds reads contribute 0.
+def bytesToUInt64BE (bytes : ByteArray) (offset : Nat) : UInt64 :=
+  let get := fun i => if offset + i < bytes.size then bytes[offset + i]!.toUInt64 else 0
   (get 0 <<< 56) ||| (get 1 <<< 48) ||| (get 2 <<< 40) ||| (get 3 <<< 32) |||
-  (get 4 <<< 24) ||| (get 5 <<< 16) ||| (get 6 <<< 8) ||| get 7
+  (get 4 <<< 24) ||| (get 5 <<< 16) ||| (get 6 <<<  8) |||  get 7
 
 -- Pad message
-def padMessage (x : List UInt8) : List UInt8 :=
-  let l      := List.length x
+def padMessage (x : ByteArray) : ByteArray :=
+  let l      := x.size
   let padn   := (240 - ((l + 1) % 128)) % 128
-  let zeroes := List.replicate padn 0x00
+  let zeroes := ⟨Array.replicate padn 0x00⟩
   if l ≥ 2 ^ 125
     then panic! "Message too long!"
-    else x ++ (0x80 :: zeroes) ++ UInt128.toUInt8BE (l * 8)
+    else x ++ ⟨#[0x80]⟩ ++ zeroes ++ UInt128.toUInt8BE (l * 8)
 
--- Process one 1024-bit chunk
-def processChunk (h : List UInt64) (chunk : List UInt8) : List UInt64 :=
+-- Process one 1024-bit chunk (128 bytes starting at `offset` in `x`)
+def processChunk (h : List UInt64) (x : ByteArray) (offset : Nat) : List UInt64 :=
   -- Parse chunk into 16 UInt64 words
-  let w0 := List.range 16 |>.map (fun i => bytesToUInt64BE chunk (i * 8))
+  let w0 := List.range 16 |>.map (fun i => bytesToUInt64BE x (offset + i * 8))
 
   -- Extend to 80 words
   let w := (List.range 64).foldl (fun w i =>
@@ -107,25 +107,26 @@ def processChunk (h : List UInt64) (chunk : List UInt8) : List UInt64 :=
   [h[0]! + a, h[1]! + b, h[2]! + c, h[3]! + d,
    h[4]! + e, h[5]! + f, h[6]! + g, h[7]! + h₀]
 
--- Process all chunks
-def processChunks (h : List UInt64) (x : List UInt8) : List UInt64 :=
-  if x.length < 128 then h
+-- Process all chunks starting at byte offset `i`
+def processChunks (h : List UInt64) (x : ByteArray) (i : Nat) : List UInt64 :=
+  if h_done : i + 128 > x.size then h
   else
-    let chunk := x.take 128
-    let h' := processChunk h chunk
-    processChunks h' (x.drop 128)
-termination_by x.length
-decreasing_by simp; omega
+    let h' := processChunk h x i
+    processChunks h' x (i + 128)
+termination_by x.size - i
+decreasing_by simp_wf; omega
+
+-- Pack the 8 final UInt64 hash values into a 64-byte ByteArray (big-endian)
+def wordsToBytes (h : List UInt64) : ByteArray :=
+  h.foldl (fun acc w => acc ++ UInt64.toUInt8BE w) ByteArray.empty
 
 -- Main hash function
-def hashMessage (x : List UInt8) : List UInt64 :=
-  processChunks initial (padMessage x)
+def hashMessage (x : ByteArray) : ByteArray :=
+  wordsToBytes (processChunks initial (padMessage x) 0)
 
 -- Hash and return hex string
 def hash (x : String) : String :=
-  let hashVals := hashMessage x.toByteList
-  let bytes := hashVals.flatMap UInt64.toUInt8BE
-  uint8ListToHex bytes
+  byteArrayToHex (hashMessage x.toByteArray)
 
 end Internal
 

--- a/Cryptograph/Sha3/Sha3_256.lean
+++ b/Cryptograph/Sha3/Sha3_256.lean
@@ -4,8 +4,8 @@ namespace Cryptograph.Sha3.Sha3_256
 
 /-! ## SHA3-256 Hash Implementation-/
 
--- SHA3-256 hash function for byte lists
-def hashBytes (input : List UInt8) : List UInt8 :=
+-- SHA3-256 hash function for byte arrays
+def hashBytes (input : ByteArray) : ByteArray :=
   Cryptograph.Keccak.Keccak256.sha3_256_hashBytes input
 
 -- SHA3-256 hash function for strings

--- a/Cryptograph/String/Basic.lean
+++ b/Cryptograph/String/Basic.lean
@@ -2,23 +2,51 @@ namespace Cryptograph.String
 
 namespace Internal
 
-def String.toByteList (x : String) : List UInt8 := x.toUTF8.toList
+/-- UTF-8 encoded bytes of a string. -/
+def String.toByteArray (x : String) : ByteArray := x.toUTF8
 
-def byteListToHex {α} {n} (f : α → BitVec n) (x : List α) : String :=
+private def hexNibble : UInt8 → Char
+  |  0 => '0'
+  |  1 => '1'
+  |  2 => '2'
+  |  3 => '3'
+  |  4 => '4'
+  |  5 => '5'
+  |  6 => '6'
+  |  7 => '7'
+  |  8 => '8'
+  |  9 => '9'
+  | 10 => 'a'
+  | 11 => 'b'
+  | 12 => 'c'
+  | 13 => 'd'
+  | 14 => 'e'
+  | 15 => 'f'
+  | _  => '?'
+
+/-- Hex-string encoding of a `ByteArray` (lowercase, no separators). -/
+def byteArrayToHex (b : ByteArray) : String :=
+  let chars := b.foldl (init := #[]) (fun acc byte =>
+    let hi := byte >>> 4
+    let lo := byte &&& 0x0F
+    acc.push (hexNibble hi) |>.push (hexNibble lo))
+  ⟨chars.toList⟩
+
+private def byteListToHex {α} {n} (f : α → BitVec n) (x : List α) : String :=
   let rec loop (acc : List Char) : List α → String
     | h :: t => loop ((h |> f |> BitVec.toHex |> String.data |> List.reverse) ++ acc) t
     | []     => ⟨List.reverse acc⟩
   loop [] x
 
-def uint8ListToHex  (x : List UInt8 ) : String := byteListToHex UInt8.toBitVec  x
+/-- Hex-string encoding of a list of 32-bit words. -/
 def uint32ListToHex (x : List UInt32) : String := byteListToHex UInt32.toBitVec x
 
 end Internal
 
 export Internal
   (
-    String.toByteList
-    uint8ListToHex
+    String.toByteArray
+    byteArrayToHex
     uint32ListToHex
   )
 

--- a/PlutusCore/ByteString/Basic.lean
+++ b/PlutusCore/ByteString/Basic.lean
@@ -185,6 +185,15 @@ def equalsByteString (b1 : ByteString) (b2 : ByteString) : Bool := b1 == b2
 def lessThanByteString (b1 : ByteString) (b2 : ByteString) : Bool := b1 < b2
 def lessThanEqualsByteString (b1 : ByteString) (b2 : ByteString) : Bool := b1 <= b2
 
+/-- Converts a UPLC `ByteString` (which wraps a `String` of codepoint-as-byte
+    chars) to its `ByteArray` representation. -/
+@[inline] def byteStringToByteArray (bs : ByteString) : ByteArray :=
+  (Char.toUInt8 <$> bs.data.data).toByteArray
+
+/-- Wrap a `ByteArray` into the UPLC `ByteString` domain value. -/
+@[inline] def byteArrayToByteString (b : ByteArray) : ByteString :=
+  ⟨String.mk (Char.ofUInt8 <$> b.toList)⟩
+
 end PlutusCore.ByteStringInternal
 
 export PlutusCore.ByteStringInternal
@@ -203,6 +212,8 @@ export PlutusCore.ByteStringInternal
     sliceByteString
     ByteString.cons
     ByteString.stringToByteString
+    byteStringToByteArray
+    byteArrayToByteString
     -- theorems
     EqByteString_equiv_EqArray
     BEqByteString_false_imp_not_eq

--- a/PlutusCore/Cbor/Basic.lean
+++ b/PlutusCore/Cbor/Basic.lean
@@ -11,7 +11,7 @@ open PlutusCore.Integer (Integer)
 -- Spec from herein refers to the Formal Specification of the Plutus Core Language
 -- found at https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf
 
-namespace CborInternal
+namespace Internal
 
 -- ==============
 -- =  Encoding  =
@@ -770,9 +770,9 @@ end
 def decodeData (s : String) : Option (String × Data) :=
   Prod.map String.mk id <$> decodeDataLoop s.data
 
-end CborInternal
+end Internal
 
-export CborInternal
+export Internal
   ( -- encoding
     encodeBytestring
     encodeInt

--- a/PlutusCore/Cbor/Tests.lean
+++ b/PlutusCore/Cbor/Tests.lean
@@ -1,7 +1,7 @@
 import PlutusCore.Cbor.Basic
 
 namespace PlutusCore.Cbor
-open PlutusCore.Cbor.CborInternal
+open PlutusCore.Cbor.Internal
 
 -- ==============
 -- =  Encoding  =

--- a/PlutusCore/Crypto/BLS12_381/G1.lean
+++ b/PlutusCore/Crypto/BLS12_381/G1.lean
@@ -34,14 +34,15 @@ opaque bls12_381_G1_scalarMul (z : Integer) (x : BLS12_381_G1_Element) : BLS12_3
 opaque bls12_381_G1_equal (x y : BLS12_381_G1_Element) : Bool := x = y
 
 opaque bls12_381_G1_hashToGroup (msg dst : ByteString) : Except String BLS12_381_G1_Element :=
-  match Fq1.hashToCurve (Char.toUInt8 <$> msg.data.data) (Char.toUInt8 <$> dst.data.data) with
+  match Fq1.hashToCurve (byteStringToByteArray msg) (byteStringToByteArray dst) with
   | .some r => .ok r
   | .none   => .error "bls12_381_G1_hashToGroup: Domain separator tag too long!"
 
-opaque bls12_381_G1_compress (p : BLS12_381_G1_Element) : ByteString := ⟨⟨Char.ofUInt8 <$> compressG1 p⟩⟩
+opaque bls12_381_G1_compress (p : BLS12_381_G1_Element) : ByteString :=
+  byteArrayToByteString (compressG1 p)
 
 opaque bls12_381_G1_uncompress (b : ByteString) : Except String BLS12_381_G1_Element :=
-  match uncompressG1 (Char.toUInt8 <$> b.data.data) with
+  match uncompressG1 (byteStringToByteArray b) with
   | .some r => .ok r
   | .none   => .error "bls12_381_G1_uncompress: invalid point"
 

--- a/PlutusCore/Crypto/BLS12_381/G2.lean
+++ b/PlutusCore/Crypto/BLS12_381/G2.lean
@@ -36,14 +36,15 @@ opaque bls12_381_G2_scalarMul (z : Integer) (x : BLS12_381_G2_Element) : BLS12_3
 opaque bls12_381_G2_equal (x y : BLS12_381_G2_Element) : Bool := x = y
 
 opaque bls12_381_G2_hashToGroup (msg dst : ByteString) : Except String BLS12_381_G2_Element :=
-  match Fq2.hashToCurve (Char.toUInt8 <$> msg.data.data) (Char.toUInt8 <$> dst.data.data) with
+  match Fq2.hashToCurve (byteStringToByteArray msg) (byteStringToByteArray dst) with
   | .some r => .ok r
   | .none   => .error "bls12_381_G2_hashToGroup: Domain separator tag too long!"
 
-opaque bls12_381_G2_compress (p : BLS12_381_G2_Element) : ByteString := ⟨⟨Char.ofUInt8 <$> compressG2 p⟩⟩
+opaque bls12_381_G2_compress (p : BLS12_381_G2_Element) : ByteString :=
+  byteArrayToByteString (compressG2 p)
 
 opaque bls12_381_G2_uncompress (b : ByteString) : Except String BLS12_381_G2_Element :=
-  match uncompressG2 (Char.toUInt8 <$> b.data.data) with
+  match uncompressG2 (byteStringToByteArray b) with
   | .some r => .ok r
   | .none   => .error "bls12_381_G2_uncompress: invalid point"
 

--- a/PlutusCore/Crypto/Ed25519/Basic.lean
+++ b/PlutusCore/Crypto/Ed25519/Basic.lean
@@ -15,11 +15,11 @@ namespace Internal
 -- pk: 32 bytes, msg: any length, sig: 64 bytes.
 -- Returns .error for invalid lengths (→ EvaluationError in CEK).
 opaque verifyEd25519Signature (publicKey message signature : ByteString) : Except String Bool :=
-  let pk  := publicKey.data.data.map Char.toUInt8
-  let msg := message.data.data.map Char.toUInt8
-  let sig := signature.data.data.map Char.toUInt8
-  if pk.length  ≠ 32 then .error "verifyEd25519Signature: pk must be 32 bytes"
-  else if sig.length ≠ 64 then .error "verifyEd25519Signature: sig must be 64 bytes"
+  let pk  := byteStringToByteArray publicKey
+  let msg := byteStringToByteArray message
+  let sig := byteStringToByteArray signature
+  if pk.size  ≠ 32 then .error "verifyEd25519Signature: pk must be 32 bytes"
+  else if sig.size ≠ 64 then .error "verifyEd25519Signature: sig must be 64 bytes"
   else .ok (Signature.verify pk msg sig)
 
 end Internal

--- a/PlutusCore/Crypto/Hash/Basic.lean
+++ b/PlutusCore/Crypto/Hash/Basic.lean
@@ -22,33 +22,22 @@ open PlutusCore.ByteString
 namespace Internal
 
 opaque sha2_256 (x : ByteString) : ByteString :=
-  let hash := Sha256.hashMessage (x.data.data.map Char.toUInt8)
-  let bytes := (Vector.toList hash).flatMap (fun (w : UInt32) =>
-    [((w >>> 24) &&& 0xFF).toUInt8,
-     ((w >>> 16) &&& 0xFF).toUInt8,
-     ((w >>> 8) &&& 0xFF).toUInt8,
-     (w &&& 0xFF).toUInt8])
-  ⟨⟨Char.ofUInt8 <$> bytes⟩⟩
+  byteArrayToByteString (Sha256.hashMessage (byteStringToByteArray x))
 
 opaque sha3_256 (x : ByteString) : ByteString :=
-  let bytes := Sha3_256.hashBytes (x.data.data.map Char.toUInt8)
-  ⟨⟨Char.ofUInt8 <$> bytes⟩⟩
+  byteArrayToByteString (Sha3_256.hashBytes (byteStringToByteArray x))
 
 opaque blake2b_224 (x : ByteString) : ByteString :=
-  let bytes := Blake2b.blake2b_224 (x.data.data.map Char.toUInt8)
-  ⟨⟨Char.ofUInt8 <$> bytes⟩⟩
+  byteArrayToByteString (Blake2b.blake2b_224 (byteStringToByteArray x))
 
 opaque blake2b_256 (x : ByteString) : ByteString :=
-  let bytes := Blake2b.blake2b_256 (x.data.data.map Char.toUInt8)
-  ⟨⟨Char.ofUInt8 <$> bytes⟩⟩
+  byteArrayToByteString (Blake2b.blake2b_256 (byteStringToByteArray x))
 
 opaque keccak_256 (x : ByteString) : ByteString :=
-  let bytes := Keccak256.hashBytes (x.data.data.map Char.toUInt8)
-  ⟨⟨Char.ofUInt8 <$> bytes⟩⟩
+  byteArrayToByteString (Keccak256.hashBytes (byteStringToByteArray x))
 
 opaque ripemd_160 (x : ByteString) : ByteString :=
-  let bytes := Ripemd160.ripemd160 (x.data.data.map Char.toUInt8)
-  ⟨⟨Char.ofUInt8 <$> bytes⟩⟩
+  byteArrayToByteString (Ripemd160.ripemd160 (byteStringToByteArray x))
 
 end Internal
 

--- a/PlutusCore/Crypto/Secp256k1/Basic.lean
+++ b/PlutusCore/Crypto/Secp256k1/Basic.lean
@@ -18,16 +18,16 @@ namespace Internal
 -- pk: 33 bytes (compressed), msg: 32 bytes (hash), sig: 64 bytes (compact r||s).
 -- Returns .error for invalid lengths or unparseable key/sig (→ EvaluationError in CEK).
 opaque verifyEcdsaSecp256k1Signature (publicKey message signature : ByteString) : Except String Bool :=
-  let pk  := Char.toUInt8 <$> publicKey.data.data
-  let msg := Char.toUInt8 <$> message.data.data
-  let sig := Char.toUInt8 <$> signature.data.data
-  if pk.length != 33 then .error "verifyEcdsaSecp256k1Signature: pk must be 33 bytes"
-  else if msg.length != 32 then .error "verifyEcdsaSecp256k1Signature: msg must be 32 bytes"
-  else if sig.length != 64 then .error "verifyEcdsaSecp256k1Signature: sig must be 64 bytes"
+  let pk  := byteStringToByteArray publicKey
+  let msg := byteStringToByteArray message
+  let sig := byteStringToByteArray signature
+  if pk.size != 33 then .error "verifyEcdsaSecp256k1Signature: pk must be 33 bytes"
+  else if msg.size != 32 then .error "verifyEcdsaSecp256k1Signature: msg must be 32 bytes"
+  else if sig.size != 64 then .error "verifyEcdsaSecp256k1Signature: sig must be 64 bytes"
   else
     -- Per Plutus spec: r or s equal to 0 or ≥ curveOrder is an evaluation error (not False)
-    let r := ECDSA.bytesToNat (sig.take 32)
-    let s := ECDSA.bytesToNat (sig.drop 32)
+    let r := ECDSA.bytesToNat (sig.extract 0 32)
+    let s := ECDSA.bytesToNat (sig.extract 32 64)
     if r == 0 || Nat.ble ECDSA.curveOrder r then .error "verifyEcdsaSecp256k1Signature: r out of range"
     else if s == 0 || Nat.ble ECDSA.curveOrder s then .error "verifyEcdsaSecp256k1Signature: s out of range"
     else match Secp256k1Point.decompress pk with
@@ -38,11 +38,11 @@ opaque verifyEcdsaSecp256k1Signature (publicKey message signature : ByteString) 
 -- pk: 32 bytes (x-only), msg: any length, sig: 64 bytes.
 -- Returns .error for invalid lengths or unparseable key (→ EvaluationError in CEK).
 opaque verifySchnorrSecp256k1Signature (publicKey message signature : ByteString) : Except String Bool :=
-  let pk  := Char.toUInt8 <$> publicKey.data.data
-  let msg := Char.toUInt8 <$> message.data.data
-  let sig := Char.toUInt8 <$> signature.data.data
-  if pk.length != 32 then .error "verifySchnorrSecp256k1Signature: pk must be 32 bytes"
-  else if sig.length != 64 then .error "verifySchnorrSecp256k1Signature: sig must be 64 bytes"
+  let pk  := byteStringToByteArray publicKey
+  let msg := byteStringToByteArray message
+  let sig := byteStringToByteArray signature
+  if pk.size != 32 then .error "verifySchnorrSecp256k1Signature: pk must be 32 bytes"
+  else if sig.size != 64 then .error "verifySchnorrSecp256k1Signature: sig must be 64 bytes"
   else match Schnorr.liftX pk with
   | none   => .error "verifySchnorrSecp256k1Signature: invalid public key"
   | some _ => .ok (Schnorr.verify pk msg sig)


### PR DESCRIPTION
## Description

Refactors the Lean implementations of Cryptograph to use ByteArrays internally (instead of Lists and/or Strings) for a sizable performance improvement.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Performance improvement
- [x] Code refactoring
- [ ] Test updates

## Related Issue

Closes https://github.com/input-output-hk/Lean-blaster/issues/121.

## Changes Made

## Changes Made

- Replaced `List UInt8` (and string-of-bytes) buffers with `ByteArray` throughout `Cryptograph/` — Blake2b, Keccak-256, RIPEMD-160, SHA-2 (256/512), SHA-3-256, Ed25519, Secp256k1 (ECDSA/Schnorr), and BLS12-381 now hash, sign, and verify directly over `ByteArray`.
- Added bridging helpers `byteStringToByteArray` / `byteArrayToByteString` in `PlutusCore/ByteString/Basic.lean` and routed every UPLC crypto/hash builtin (`PlutusCore/Crypto/**`) through them, eliminating the per-byte `Char.toUInt8` / `Char.ofUInt8` round-trips at the builtin boundary.
- Reworked `Cryptograph/String/Basic.lean`: dropped `String.toByteList` / `uint8ListToHex` in favor of `String.toByteArray` and a new `byteArrayToHex` (table-driven nibble encoder).
- Updated test vectors and conformance call sites to match the new `ByteArray`-based signatures; no behavioral changes — existing tests and conformance suite still pass.

## Testing

Tests, test vectors and conformance tests already existed.

### Test Coverage

- [ ] Added new tests for new functionality
- [x] Updated existing tests
- [x] All tests pass locally

## Documentation

- [ ] README updated (if applicable)
- [x] Code comments added/updated
- [x] Doc comments added for new optimization/rewritting rules

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes using `make check_all`
