### PR TITLE
plutus-core: Adding irrefl instance for ByteString

### DIFF
--- a/PlutusCore/ByteString/Basic.lean
+++ b/PlutusCore/ByteString/Basic.lean
@@ -112,11 +112,15 @@ theorem UInt8.lt_irrefl (x : UInt8) : ¬ x < x := by
 instance : Std.Irrefl ( . < . : UInt8 → UInt8 → Prop) where
   irrefl := UInt8.lt_irrefl
 
+/-! Std.Irrefl instance for ByteString -/
 @[simp] theorem ByteString.lt_irrefl (x : ByteString) : ¬ x < x := by
   match x with
   | ByteString.mk v =>
        unfold LT.lt LTByteString
        apply List.lt_irrefl
+
+instance : Std.Irrefl (. < . : ByteString → ByteString → Prop) where
+  irrefl := ByteString.lt_irrefl
 
 @[simp] def ByteString.length (bs : ByteString) : Nat := bs.data.length
 


### PR DESCRIPTION
## Description

Adding `Std.Irrefl` instance for `ByteString.` 
This modification is necessary for two reasons:
 - The instance is necessary when we want to derive  the `irrefl` instance in other formalization (e.g., `CardanoLedgerApi)` on inductive datatypes that depend on `ByteString`. 
 - We want to extend Blaster optimization passes to optimize `Lt.lt` with defined `Std.Irrefl` instances.


## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test updates

## Changes Made

- Adding `Std.Irrefl` instance for ByteString
-  irrefl theorem is discharged by already proved theorem `ByteString.lt_irrefl`

## Documentation

- [ ] README updated (if applicable)
- [x] Code comments added/updated
- [ ] Doc comments added for new optimization/rewritting rules

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes using `make check_all`
