### PR TITLE
fix: CBOR codec fidelity (empty collections, empty bytestring, negative bignum, constr index)

### DIFF
--- a/PlutusCore/Cbor/Basic.lean
+++ b/PlutusCore/Cbor/Basic.lean
@@ -86,7 +86,7 @@ def encodeBytestringChunk (s : String) : Option (List Char) := do
 -- Spec B.5. ε_B*
 def encodeBytestring (s : String) : Option String :=
   match splitToChunks s with
-  | []      => .some ""
+  | []      => String.mk <$> encodeHead 2 0  -- empty bytestring is a definite 0-length string (0x40)
   | h :: [] => String.mk <$> encodeBytestringChunk h
   | chunks  => do .some ⟨encodeIndef 2 :: (List.concat (←List.flatMapM encodeBytestringChunk chunks) '\xFF')⟩
 
@@ -125,18 +125,26 @@ def encodeCtag (i : Integer) : Option String :=
 /-- Encode data (builtinData). -/
 -- Spec B.7. Encoding and  decoding Data. ε_data
 def encodeData : Data → Option String
-  | .Constr idx fields => do
-      (←encodeCtag idx)
-      ++ (encodeIndef 4 |> String.singleton)
-      ++ (←List.foldlM (λ s a => do .some (s ++ (←encodeData a))) "" fields)
-      ++ "\xFF"
+  | .Constr idx fields =>
+      if fields.isEmpty then do
+        -- empty field list is a DEFINITE empty array (0x80), matching the serialiseData builtin
+        (←encodeCtag idx) ++ (String.mk (←encodeHead 4 0))
+      else do
+        (←encodeCtag idx)
+        ++ (encodeIndef 4 |> String.singleton)
+        ++ (←List.foldlM (λ s a => do .some (s ++ (←encodeData a))) "" fields)
+        ++ "\xFF"
   | .Map mxs => do
       ((←encodeHead 5 (List.length mxs)) |> String.mk)
       ++ (←List.foldlM (λ s p => do .some (s ++ (←encodeData p.fst) ++ (←encodeData p.snd))) "" mxs)
-  | .List xs => do
-      (encodeIndef 4 |> String.singleton)
-      ++ (←List.foldlM (λ s a => do .some (s ++ (←encodeData a))) "" xs)
-      ++ "\xFF"
+  | .List xs =>
+      if xs.isEmpty then
+        -- empty list is a DEFINITE empty array (0x80), matching the serialiseData builtin
+        String.mk <$> encodeHead 4 0
+      else do
+        (encodeIndef 4 |> String.singleton)
+        ++ (←List.foldlM (λ s a => do .some (s ++ (←encodeData a))) "" xs)
+        ++ "\xFF"
   | .I i => encodeInt i
   | .B bs => encodeBytestring bs.data
 
@@ -556,7 +564,7 @@ def decodeInt (s : String) : Option (String × Integer) :=
   | .some (s', 0, n) => .some (⟨s'⟩,  (Int.ofNat n)    )
   | .some (s', 1, n) => .some (⟨s'⟩, -(Int.ofNat n) - 1)
   | .some (s', 6, 2) => (λ (s'', b) => (s'',              stoi b      )) <$> decodeBytestring ⟨s'⟩
-  | .some (s', 6, 3) => (λ (s'', b) => (s'', -(Int.ofNat (stoi b) - 1))) <$> decodeBytestring ⟨s'⟩
+  | .some (s', 6, 3) => (λ (s'', b) => (s'', -(Int.ofNat (stoi b)) - 1)) <$> decodeBytestring ⟨s'⟩
   | _                => .none
 
 /-- Helper theorem: decodeInt consumes at least one byte on success -/
@@ -613,9 +621,14 @@ theorem decodeInt_consumes (s : String) :
 def decodeCtag (s : List Char) : Option (List Char × Integer) :=
   match decodeHead s with
   | .some (s', 6, 102) => do
+      -- Only the definite 2-element wrapper (0x82) is accepted.
       let (s'', m, n) ← decodeHead s'
       if m = 4 ∧ n = 2
-        then Prod.map String.data id <$> decodeInt ⟨s''⟩
+        then do
+          -- Index is a direct Word64 (matches decodeWord64). A negative or bignum-encoded
+          -- index is write-only, so reject it on decode.
+          let (s''', im, iv) ← decodeHead s''
+          if im = 0 then .some (s''', Int.ofNat iv) else .none
         else .none
   | .some (s', 6, i) =>      if  121 ≤ i ∧ i ≤  127 then .some (s',  i -  121     )
                         else if 1280 ≤ i ∧ i ≤ 1400 then .some (s', (i - 1280) + 7)
@@ -657,23 +670,23 @@ theorem decodeCtag_consumes (s : List Char) :
     simp only [Option.bind_eq_bind, Option.bind_eq_some_iff] at h
     obtain ⟨⟨s''', m, n⟩, hdh2, h_rest⟩ := h
     split at h_rest
-    · -- decodeInt succeeds (split confirms m = 4 and n = 2)
+    · -- index decode succeeds (split confirms m = 4 and n = 2), index is a direct Word64
       rename_i heq_mn
-      cases h_int : decodeInt ⟨s'''⟩ with
-      | none => simp [h_int] at h_rest
-      | some res =>
-        simp [h_int, Prod.map] at h_rest
-        obtain ⟨h_eq_s', h_eq_i⟩ := h_rest
+      simp only [Option.bind_eq_some_iff] at h_rest
+      obtain ⟨⟨s4, im, iv⟩, hdh3, h_rest2⟩ := h_rest
+      split at h_rest2
+      · rename_i him
+        simp at h_rest2
+        obtain ⟨h_eq_s', h_eq_i⟩ := h_rest2
         have h_head1 := decodeHead_consumes s k 6 102 hdh
-        -- Use heq_mn to show m = 4 and n = 2
         have ⟨hm, hn⟩ : m = 4 ∧ n = 2 := heq_mn
         subst hm hn
         have h_head2 := decodeHead_consumes k s''' 4 2 hdh2
-        have h_int_cons := decodeInt_consumes ⟨s'''⟩ res.1 res.2 h_int
-        simp at h_int_cons
+        subst him
+        have h_head3 := decodeHead_consumes s''' s4 0 iv hdh3
         rw [← h_eq_s']
-        simp
         omega
+      · simp at h_rest2
     · simp at h_rest
   · -- Case: decodeHead s = some (s'', 6, i_val) with i_val ≠ 102
     rename_i s'' i_val hne hdh

--- a/PlutusCore/Cbor/Tests.lean
+++ b/PlutusCore/Cbor/Tests.lean
@@ -93,4 +93,82 @@ example : decodeData "\xd8\x79\x9f\x1a\x08\x9a\xfe\x76\x19\x58\xb6\x1b\x00\x00\x
       ]
   ) := by native_decide
 
+-- Empty collections encode as a DEFINITE empty array (0x80), matching the on-chain
+-- serialiseData builtin (aiken/cbor.serialise), not an indefinite 0x9f..0xff.
+-- (The List [], Constr 0, and nested cases are byte-anchored in the reference fixtures below.)
+example : encodeData (.Constr 1 []) = .some "\xd8\x7a\x80" := by native_decide
+example : encodeData (.Constr 7 []) = .some "\xd9\x05\x00\x80" := by native_decide
+
+-- decodeData round-trips negative bignums (tag 3), not just positive (tag 2).
+example : (encodeData (.I (-(2 ^ 512 + 1)))).bind decodeData = .some ("", .I (-(2 ^ 512 + 1))) := by native_decide
+
+-- Byte-anchored DECODE vector pinning the tag-1/tag-3 boundary: `-(2^64)` is the largest negative
+-- on the major-type-1 side. `-(2^64+1)` (first tag-3 negative bignum) is byte-anchored in the
+-- reference fixtures below, and would decode wrong under the old `1 - m` sign bug.
+example : decodeData "\x3b\xff\xff\xff\xff\xff\xff\xff\xff" = .some ("", .I (-(2 ^ 64))) := by native_decide
+example : (encodeData (.I (2 ^ 512))).bind decodeData = .some ("", .I (2 ^ 512)) := by native_decide
+example : (encodeData (.Constr 1 [])).bind decodeData = .some ("", .Constr 1 []) := by native_decide
+
+-- An empty ByteString is a definite 0-length string (0x40), not zero bytes, and round-trips.
+-- (The bare 0x40 and the empty-B-in-map cases are byte-anchored in the reference fixtures below.)
+example : (encodeData (.B { data := "" })).bind decodeData = .some ("", .B { data := "" }) := by native_decide
+example : (encodeData (.List [.B { data := "" }, .I 5])).bind decodeData
+  = .some ("", .List [.B { data := "" }, .I 5]) := by native_decide
+
+-- Constructor index > 127 uses the tag-102 fallback. The index must be a direct Word64: in-range
+-- indices (128, 2^63-1, 2^64-1) are byte-anchored in the reference fixtures below. An index >= 2^64
+-- or a negative index is rejected on decode, matching the real ledger decoder (decodeWord64), even
+-- though serialiseData will emit it (write-only).
+example : (encodeData (.Constr (2 ^ 64) [.I 1])).bind decodeData = .none := by native_decide
+example : (encodeData (.Constr (-1) [])).bind decodeData = .none := by native_decide
+
+-- Map round-trips through decodePairList (definite-length map header + key/value pairs).
+example : (encodeData (.Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [.I 4])])).bind decodeData
+  = .some ("", .Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [.I 4])]) := by native_decide
+
+-- Reference fixtures: golden CBOR vectors for the shapes this PR touches (empty containers, empty
+-- bytestring, negative bignums, tag-102 indices, nesting). Each pins `encodeData` to fixed bytes
+-- and `decodeData` to invert them. The bytes are the canonical CBOR encoding mandated by the
+-- reference (`Data.hs` / cborg / RFC 8949), hand-verifiable byte by byte, so the encode direction
+-- is a genuine anchor and not a self-referential round-trip.
+-- emptyList
+example : encodeData (.List []) = .some "\x80" := by native_decide
+example : decodeData "\x80" = .some ("", .List []) := by native_decide
+-- emptyConstr0
+example : encodeData (.Constr 0 []) = .some "\xd8\x79\x80" := by native_decide
+example : decodeData "\xd8\x79\x80" = .some ("", .Constr 0 []) := by native_decide
+-- emptyConstr5
+example : encodeData (.Constr 5 []) = .some "\xd8\x7e\x80" := by native_decide
+example : decodeData "\xd8\x7e\x80" = .some ("", .Constr 5 []) := by native_decide
+-- emptyB
+example : encodeData (.B { data := "" }) = .some "\x40" := by native_decide
+example : decodeData "\x40" = .some ("", .B { data := "" }) := by native_decide
+-- mapEmptyB
+example : encodeData (.Map [(.B { data := "" }, .I 0)]) = .some "\xa1\x40\x00" := by native_decide
+example : decodeData "\xa1\x40\x00" = .some ("", .Map [(.B { data := "" }, .I 0)]) := by native_decide
+-- negBignum64
+example : encodeData (.I (-(2 ^ 64 + 1))) = .some "\xc3\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00" := by native_decide
+example : decodeData "\xc3\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00" = .some ("", .I (-(2 ^ 64 + 1))) := by native_decide
+-- negBignum128
+example : encodeData (.I (-(2 ^ 128))) = .some "\xc3\x50\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" := by native_decide
+example : decodeData "\xc3\x50\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" = .some ("", .I (-(2 ^ 128))) := by native_decide
+-- constr128
+example : encodeData (.Constr 128 []) = .some "\xd8\x66\x82\x18\x80\x80" := by native_decide
+example : decodeData "\xd8\x66\x82\x18\x80\x80" = .some ("", .Constr 128 []) := by native_decide
+-- constrBig (2^63-1)
+example : encodeData (.Constr (2 ^ 63 - 1) [.I 1]) = .some "\xd8\x66\x82\x1b\x7f\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff" := by native_decide
+example : decodeData "\xd8\x66\x82\x1b\x7f\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff" = .some ("", .Constr (2 ^ 63 - 1) [.I 1]) := by native_decide
+-- constrMax (2^64-1, the largest in-range Word64 index)
+example : encodeData (.Constr (2 ^ 64 - 1) [.I 1]) = .some "\xd8\x66\x82\x1b\xff\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff" := by native_decide
+example : decodeData "\xd8\x66\x82\x1b\xff\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff" = .some ("", .Constr (2 ^ 64 - 1) [.I 1]) := by native_decide
+-- nested
+example : encodeData (.Constr 0 [.List [], .I 5]) = .some "\xd8\x79\x9f\x80\x05\xff" := by native_decide
+example : decodeData "\xd8\x79\x9f\x80\x05\xff" = .some ("", .Constr 0 [.List [], .I 5]) := by native_decide
+-- mapKV
+example : encodeData (.Map [(.I 0, .I 1)]) = .some "\xa1\x00\x01" := by native_decide
+example : decodeData "\xa1\x00\x01" = .some ("", .Map [(.I 0, .I 1)]) := by native_decide
+-- listII
+example : encodeData (.List [.I 1, .I 2]) = .some "\x9f\x01\x02\xff" := by native_decide
+example : decodeData "\x9f\x01\x02\xff" = .some ("", .List [.I 1, .I 2]) := by native_decide
+
 end PlutusCore.Cbor


### PR DESCRIPTION

## Description

Four corrections to the CBOR `Data` codec (`PlutusCore/Cbor/Basic.lean`) so that `encodeData` matches the on-chain `serialiseData` builtin and `decodeData` decodes to the correct value. Two are encoder byte-output corrections, two are decoder corrections (one value bug, one narrowing). Each change agrees with both the formal spec (Appendix B) and `IntersectMBO/plutus` `PlutusCore/Data.hs`, so it is target-agnostic. Each is covered by a test.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature
- [x] Breaking change: the encoder byte output (items 1 and 2) and the decoder behaviour (items 3 and 4) change on previously-valid inputs

Items 1 and 2 change the encoder's bytes for empty containers and empty bytestrings, so any consumer holding old bytes or hashes for those shapes sees different (now-correct) output. Item 3 changes the decoded value of existing tag-3 negative-bignum bytes, and item 4 now rejects tag-102 indices (bignum or negative) that previously decoded via `decodeInt`. All four are corrections toward the reference, but they change observable behaviour on previously-valid inputs, so this is flagged breaking.

## Related Issue

Companion issue: #22 reports the three fidelity bugs (empty-collection encoding, empty-bytestring encoding, negative-bignum decode). The tag-102 index narrowing is a related hardening described inline. All four are covered by tests.

## Changes Made

Encoder (byte-output corrections):

- `encodeData`: empty constructor fields and empty lists now encode as a definite empty array (`0x80`), not indefinite `0x9f..0xff`. Matches `Data.hs`, which encodes `[Data]` with cborg's list instance: `[]` uses `encodeListLen 0` (`0x80`), nonempty uses `encodeListLenIndef .. encodeBreak`.
- `encodeBytestring`: an empty bytestring now encodes as a definite 0-length string (`0x40`) instead of zero bytes. Matches `Data.hs` `encodeBs`/`encodeBytes ""` = `0x40`. The old `[] => .some ""` branch was reachable (`splitToChunks "" = []`) and corrupted any `Data` containing an empty `B`.

Decoder:

- `decodeInt` (value bug): the tag-3 (negative bignum) case computed `1 - m` instead of `-1 - m`, so every negative bignum with magnitude at least `2^64 + 1` decoded to the wrong value. RFC 8949 section 3.4.3: a tag-3 value is `-1 - n`. Byte output is unchanged; only the decoded value is fixed.
- `decodeCtag` (narrowing): the tag-102 constructor index is now read as a direct `Word64` (major-type-0 in `[0, 2^64-1]`), matching `Data.hs` `encodeWord64`/`decodeWord64`. A negative or bignum-encoded index is rejected on decode. The encoder still emits such out-of-range indices (via `encodeInt`), and this encode-succeeds / decode-rejects asymmetry is present in real Plutus too (`encodeInteger` vs `decodeWord64`), so it is reproduced faithfully. The tag-102 wrapper stays definite-only (`0x82`), matching Spec B.7; this PR does not change that.

## Testing

Each change is verified against the reference (`Data.hs`, RFC 8949) and pinned by tests in `PlutusCore/Cbor/Tests.lean` (machine-checked via `native_decide`):

- Reference fixtures: 13 golden CBOR vectors (11 touching the fixed paths, 2 unchanged-behaviour controls) whose expected bytes are the canonical CBOR encoding mandated by the reference (`Data.hs` / cborg / RFC 8949), hand-verifiable byte by byte. Each pins `encodeData` to the fixed bytes and `decodeData` to invert them, so the encode direction is a genuine anchor, not a self-referential round-trip.
- Byte-anchored decoder vector at the tag-1/tag-3 boundary (`-(2^64)`), and the tag-3 fixture at `-(2^64+1)`, which fails under the old `1 - m` bug, so it is a non-tautological guard for the value fix.
- The tag-102 index is byte-anchored at `128`, `2^63-1`, and `2^64-1` (the max in-range Word64) in the fixtures, while an index `>= 2^64` and a negative index are rejected.

`make check_all` passes locally (clean build plus all tests). CI runs the same underlying checks as two separate steps (`check_plutus_core` and `check_tests`).

### Test Coverage

- [x] Added new tests for new functionality
- [x] All tests pass locally
- [ ] For bug fixes: Added example to `Tests/Issues/` folder (no such folder exists in the repo, so vectors were added to `Tests.lean`, matching the existing convention)

## Documentation

- [ ] README updated (n/a)
- [x] Code comments added/updated (each change is commented in `Basic.lean` with the `Data.hs` / RFC / spec reference)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review performed
- [x] Added tests that prove the fix
- [x] `make check_all` passes locally

## Additional Notes

Conformance (`ci-conformance.yaml`) is gated behind a `/run-conformance` comment from a maintainer and cannot be triggered by an outside contributor. This change is corrective toward the reference builtin, so I do not expect a regression, but please run `/run-conformance` against `IntersectMBO/plutus` before merge.

Scope is value and encoder fidelity only: every change here agrees with both the formal spec and `Data.hs`.
