### PR TITLE
feat: accept indefinite-length CBOR maps and constructor wrappers on decode (match Data.hs)

### DIFF
--- a/PlutusCore/Cbor/Basic.lean
+++ b/PlutusCore/Cbor/Basic.lean
@@ -621,7 +621,8 @@ theorem decodeInt_consumes (s : String) :
 def decodeCtag (s : List Char) : Option (List Char × Integer) :=
   match decodeHead s with
   | .some (s', 6, 102) => do
-      -- Only the definite 2-element wrapper (0x82) is accepted.
+      -- The definite 2-element wrapper (0x82) is accepted here. The indefinite form
+      -- (0x9f..0xff) that Data.hs also accepts is handled by decodeIndefConstr.
       let (s'', m, n) ← decodeHead s'
       if m = 4 ∧ n = 2
         then do
@@ -714,6 +715,7 @@ mutual
     match decodeAlternative decodeIndef decodeHead s with
     | .some (_ , .inl 2     ) => Prod.map String.data (.B ∘ ByteString.mk) <$> decodeBytestring ⟨s⟩
     | .some (s', .inl 4     ) => Prod.map id          .List                <$> decodeListIndef s'
+    | .some (s', .inl 5     ) => Prod.map id          .Map                 <$> decodePairListIndef s'
     | .some (_ , .inr (0, _))
     | .some (_ , .inr (1, _))
     | .some (_ , .inr (6, 2))
@@ -753,6 +755,39 @@ mutual
             | none => none
         | none => none
 
+  -- Decode an indefinite-length list of Data pairs (an indefinite-length Map, 0xbf..0xff). Spec B.7
+  -- D_data decodes maps as definite-only, so this EXTENDS the decoder beyond the spec to the
+  -- indefinite form Data.hs also accepts (decodeMapLenOrIndef). Decode-only, the encoder still
+  -- emits only definite maps.
+  partial def decodePairListIndef : List Char → Option (List Char × List (Data × Data))
+    | '\xFF' :: s' => .some (s', [])
+    | s            => match decodeDataLoop s with
+        | some (s', k) => match decodeDataLoop s' with
+            | some (s'', v) => match decodePairListIndef s'' with
+                | some (s''', l) => some (s''', (k, v) :: l)
+                | none => none
+            | none => none
+        | none => none
+
+  -- Decode a constructor whose tag-102 wrapper uses the INDEFINITE 2-element array
+  -- (0x9f index args 0xff), the form Data.hs accepts via decodeListLenOrIndef. The canonical
+  -- encoder never emits it, so this is decode-only leniency toward the reference implementation.
+  partial def decodeIndefConstr (s : List Char) : Option (List Char × Data) :=
+    match decodeHead s with
+    | .some (s', 6, 102) => match decodeIndef s' with
+        | .some (s'', 4) => match decodeHead s'' with
+            | .some (s3, 0, iv) => match decodeAlternative decodeIndef decodeHead s3 with
+                | .some (s4, .inl 4     ) => match decodeListIndef s4 with
+                    | .some ('\xFF' :: s6, args) => .some (s6, .Constr (Int.ofNat iv) args)
+                    | _                          => .none
+                | .some (s4, .inr (4, n)) => match decodeList n s4 with
+                    | .some ('\xFF' :: s6, args) => .some (s6, .Constr (Int.ofNat iv) args)
+                    | _                          => .none
+                | _                       => .none
+            | _ => .none
+        | _ => .none
+    | _ => .none
+
   -- Decode a constructor (Constr tag + list of Data values)
   partial def decodeConstr (s : List Char) : Option (List Char × Data) :=
     match decodeCtag s with
@@ -762,11 +797,13 @@ mutual
             | .inr (4, n) => Prod.map id (.Constr i) <$> decodeList n s''
             | _           => .none
         | none => none
-    | none => none
+    | none => decodeIndefConstr s
 end
 
 /- Decodes a builtin data from input `s`. -/
--- Spec B.7. D_data
+-- Spec B.7. D_data, EXTENDED beyond the spec on two indefinite-length forms the spec rejects but
+-- Data.hs accepts: indefinite maps (decodePairListIndef) and the indefinite tag-102 constructor
+-- wrapper (decodeIndefConstr). Decode-only, the encoder is unchanged.
 def decodeData (s : String) : Option (String × Data) :=
   Prod.map String.mk id <$> decodeDataLoop s.data
 

--- a/PlutusCore/Cbor/Tests.lean
+++ b/PlutusCore/Cbor/Tests.lean
@@ -126,6 +126,61 @@ example : (encodeData (.Constr (-1) [])).bind decodeData = .none := by native_de
 example : (encodeData (.Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [.I 4])])).bind decodeData
   = .some ("", .Map [(.I 1, .B { data := "aa" }), (.List [], .Constr 3 [.I 4])]) := by native_decide
 
+-- Haskell conformance for indefinite-length forms. Data.hs accepts BOTH the canonical definite
+-- encoding and an indefinite one, for maps (decodeMapLenOrIndef) and the tag-102 constructor wrapper
+-- (decodeConstrExtended via decodeListLenOrIndef). For each shape below, the canonical definite form
+-- is exactly what encodeData emits, and both the definite form and the indefinite form decode to the
+-- SAME value. That pins the indefinite-form leniency to semantic equivalence with the canonical
+-- encoding, not merely to acceptance.
+
+-- Map [(I 1, I 2)]
+example : encodeData (.Map [(.I 1, .I 2)]) = .some "\xa1\x01\x02"          := by native_decide
+example : decodeData "\xa1\x01\x02"        = .some ("", .Map [(.I 1, .I 2)]) := by native_decide
+example : decodeData "\xbf\x01\x02\xff"    = .some ("", .Map [(.I 1, .I 2)]) := by native_decide
+-- Map []
+example : encodeData (.Map []) = .some "\xa0"        := by native_decide
+example : decodeData "\xa0"    = .some ("", .Map []) := by native_decide
+example : decodeData "\xbf\xff" = .some ("", .Map []) := by native_decide
+-- Constr 200 [] (index > 127 uses the tag-102 wrapper)
+example : encodeData (.Constr 200 [])   = .some "\xd8\x66\x82\x18\xc8\x80"     := by native_decide
+example : decodeData "\xd8\x66\x82\x18\xc8\x80"     = .some ("", .Constr 200 []) := by native_decide
+example : decodeData "\xd8\x66\x9f\x18\xc8\x80\xff" = .some ("", .Constr 200 []) := by native_decide
+-- Constr 200 [I 1, I 2]
+example : encodeData (.Constr 200 [.I 1, .I 2]) = .some "\xd8\x66\x82\x18\xc8\x9f\x01\x02\xff"      := by native_decide
+example : decodeData "\xd8\x66\x82\x18\xc8\x9f\x01\x02\xff"      = .some ("", .Constr 200 [.I 1, .I 2]) := by native_decide
+example : decodeData "\xd8\x66\x9f\x18\xc8\x9f\x01\x02\xff\xff"  = .some ("", .Constr 200 [.I 1, .I 2]) := by native_decide
+
+-- Inside the indefinite wrapper the args may be definite (0x82) or indefinite (0x9f), both accepted
+-- by Data.hs and both decoding identically.
+example : decodeData "\xd8\x66\x9f\x18\xc8\x82\x01\x02\xff" = .some ("", .Constr 200 [.I 1, .I 2]) := by native_decide
+-- The indefinite wrapper enforces the same structure Data.hs does: a Word64 index, exactly two
+-- elements (index and args), and a closing break. A negative index, a missing break, or a third
+-- element is rejected. Nesting an indefinite wrapper inside another decodes.
+example : decodeData "\xd8\x66\x9f\x20\x80\xff"         = .none := by native_decide
+example : decodeData "\xd8\x66\x9f\x18\xc8\x80"         = .none := by native_decide
+example : decodeData "\xd8\x66\x9f\x18\xc8\x80\x80\xff" = .none := by native_decide
+example : decodeData "\xd8\x66\x9f\x18\xc8\x9f\xd8\x66\x9f\x18\xc9\x80\xff\xff\xff" = .some ("", .Constr 200 [.Constr 201 []]) := by native_decide
+
+-- Additional Data.hs-conformance coverage. The index through the indefinite wrapper is read by a
+-- separate path (decodeIndefConstr), so anchor it at the same Word64 boundaries the definite path
+-- uses, and reject an out-of-range (bignum) index there too.
+example : decodeData "\xd8\x66\x9f\x1b\xff\xff\xff\xff\xff\xff\xff\xff\x9f\x01\xff\xff" = .some ("", .Constr (2 ^ 64 - 1) [.I 1]) := by native_decide
+example : decodeData "\xd8\x66\x9f\x1b\x80\x00\x00\x00\x00\x00\x00\x00\x80\xff" = .some ("", .Constr (2 ^ 63) []) := by native_decide
+example : decodeData "\xd8\x66\x9f\xc2\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00\x80\xff" = .none := by native_decide
+-- A non-canonical small index (< 128) is valid in the wrapper too (Data.hs decodeWord64 accepts it).
+example : decodeData "\xd8\x66\x9f\x00\x80\xff" = .some ("", .Constr 0 []) := by native_decide
+-- The "exactly two elements" rule is on the OUTER wrapper array; the args list itself is any length.
+example : decodeData "\xd8\x66\x9f\x18\xc8\x83\x01\x02\x03\xff" = .some ("", .Constr 200 [.I 1, .I 2, .I 3]) := by native_decide
+-- Reject a third element or a missing break when the args is an INDEFINITE list (the other args branch).
+example : decodeData "\xd8\x66\x9f\x18\xc8\x9f\xff\x00\xff" = .none := by native_decide
+example : decodeData "\xd8\x66\x9f\x18\xc8\x9f\xff" = .none := by native_decide
+-- Indefinite maps: multiple pairs preserve order, a break between key and value is rejected, maps nest.
+example : decodeData "\xbf\x01\x02\x03\x04\xff" = .some ("", .Map [(.I 1, .I 2), (.I 3, .I 4)]) := by native_decide
+example : decodeData "\xbf\x01\xff" = .none := by native_decide
+example : decodeData "\xbf\x01\xbf\x02\x03\xff\xff" = .some ("", .Map [(.I 1, .Map [(.I 2, .I 3)])]) := by native_decide
+-- Cross-form nesting: an indefinite map inside an indefinite-wrapper constructor's args.
+example : decodeData "\xd8\x66\x9f\x18\xc8\x9f\xbf\x01\x02\xff\xff\xff" = .some ("", .Constr 200 [.Map [(.I 1, .I 2)]]) := by native_decide
+
 -- Reference fixtures: golden CBOR vectors for the shapes this PR touches (empty containers, empty
 -- bytestring, negative bignums, tag-102 indices, nesting). Each pins `encodeData` to fixed bytes
 -- and `decodeData` to invert them. The bytes are the canonical CBOR encoding mandated by the


### PR DESCRIPTION

## Description

This is a proposal, offered for the maintainers to accept or decline. It makes `decodeData` accept the two indefinite-length CBOR forms the reference decoder ([`IntersectMBO/plutus` `PlutusCore/Data.hs`](https://github.com/IntersectMBO/plutus/blob/3fd47e185b6e8d0ab4a8eeb655ca440eac68dbf9/plutus-core/plutus-core/src/PlutusCore/Data.hs)) accepts but this codec rejects: indefinite-length maps (`0xbf .. 0xff`) and the indefinite-length tag-102 constructor wrapper (`0x9f .. 0xff`). It is decode-only. The encoder is unchanged, so `serialiseData` output is unchanged, and each accepted indefinite form decodes to the same value the canonical encoding does.

The formal spec is deliberately stricter here (see Rationale), so this is a choice of reference, not a defect fix. If you would rather the codec stay spec-faithful, this can be closed with no cost. The recommendation, and the reason for opening it as a concrete change rather than only an issue, is spelled out under Rationale.

## Type of Change

- [x] New feature (non-breaking change adding functionality): indefinite-length map and constructor-wrapper decode
- [ ] Bug fix
- [ ] Breaking change

Decode-only and strictly more accepting. No existing input changes meaning, and no encoder output changes.

## Related Issue

Companion issue: #24 frames the underlying question (should the Data codec's decode accept-set track the spec or `Data.hs` on these two forms).

## Changes Made

- `decodeData`: an indefinite-length map header (`0xbf`) now dispatches to a new `decodePairListIndef`, which reads key/value pairs until the `0xff` break. Mirrors the reference `decodeData` dispatching `TypeMapLenIndef` to [`decodeMap`](https://github.com/IntersectMBO/plutus/blob/3fd47e185b6e8d0ab4a8eeb655ca440eac68dbf9/plutus-core/plutus-core/src/PlutusCore/Data.hs#L277-L279) (`decodeMapLenOrIndef`).
- `decodeConstr`: when the tag-102 wrapper is not the definite `0x82` array, it falls back to a new `decodeIndefConstr`, which parses `tag 102, 0x9f, index, args, 0xff`. Mirrors [`decodeConstrExtended`](https://github.com/IntersectMBO/plutus/blob/3fd47e185b6e8d0ab4a8eeb655ca440eac68dbf9/plutus-core/plutus-core/src/PlutusCore/Data.hs#L298-L307), which reads the wrapper with `decodeListLenOrIndef` and enforces exactly two elements. The indefinite path reads the index with the same major-type-0 / `Word64` constraint the definite `decodeCtag` uses. `decodeCtag` itself is unchanged.
- The `-- Spec B.7 D_data` annotation is updated (and the new `decodePairListIndef` comment states) that the decoder now extends beyond the (definite-only) spec to these two forms, so the annotations do not imply spec-conformance they no longer have.

## Testing

Machine-checked in `PlutusCore/Cbor/Tests.lean`. The core evidence is a definite/indefinite equivalence triple per shape, so acceptance is pinned to decoding the same value as the canonical encoding, not merely to "some bytes decode":

- For `Map [(I 1, I 2)]`, `Map []`, `Constr 200 []`, and `Constr 200 [I 1, I 2]`: `encodeData V` is asserted to equal the bytes the encoder emits, `decodeData` of those bytes returns `V`, and `decodeData` of the indefinite form returns the same `V`. (For nonempty args the encoder's own bytes already contain an indefinite args list, so the definite-vs-indefinite contrast here is the outer wrapper, `0x82` vs `0x9f`, not the whole encoding.)
- The indefinite wrapper reads its index with the same major-type-0 / `Word64` constraint as the definite path, exercised at `2^63` and `2^64-1` (accept) and a bignum-tagged index (reject). A tag-102 wrapper carrying a small index also decodes, matching `decodeWord64`.
- Args length is exercised beyond two (a 3-element args list), since the exactly-two rule is on the outer wrapper, not the args. Inside the wrapper the args may be definite (`0x82`) or indefinite (`0x9f`), both accepted by `Data.hs` and decoding identically.
- Rejection vectors: a negative (major-type-1) index is rejected at the index read. A missing outer break and a third element before the break are rejected on both the definite-args and indefinite-args branches. Indefinite maps preserve pair order, reject a break between a key and its value, and nest (including a map inside an indefinite-wrapper constructor's args).

`make check_all` passes locally (clean build plus all tests). CI runs the same underlying checks as two separate steps (`check_plutus_core` and `check_tests`).

### Test Coverage

- [x] Added new tests for new functionality
- [x] All tests pass locally

## Documentation

- [x] Code comments added/updated (`decodePairListIndef` and `decodeIndefConstr` reference the corresponding `Data.hs` decoders, and the `D_data` annotation notes the extension beyond the spec)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review performed
- [x] Added tests that prove the new behaviour
- [x] `make check_all` passes locally

## Rationale (why propose this, and why it is a choice not a defect)

The formal spec ([Appendix B](https://plutus.cardano.intersectmbo.org/resources/plutus-core-spec.pdf)) is deliberately stricter than `Data.hs` on these two forms: the `D_ctag` rule fixes the wrapper at a definite head, and the spec states "the decoder for Map only accepts definite-length lists." So the codec's current strictness is spec-faithful, and this change is a decision to track the implementation instead, on the decode accept-set, for these forms.

The tradeoff of accepting: the reason to want it is that `Data.hs` is the deserialiser the live network runs, so its accept-set is what actually governs bytes that reach a script. The cost is that the decoder is no longer a spec-faithful definite-only decoder on these forms (the annotations now say so), and it accepts non-canonical inputs the encoder never emits. Round-trip on the encoder's image (`decode ∘ encode = id`) is unaffected, since the encoder emits neither newly-accepted form (it emits definite maps and the definite `0x82` outer wrapper, and it is unchanged here).

Recommendation: accept, to align the decode accept-set with the implementation. But this is the maintainers' call on the codec's reference, and closing this PR is the right move if you prefer the codec stay spec-faithful here.

Please run `/run-conformance` against `IntersectMBO/plutus` before merge. This only widens the decoder's accept-set and does not touch the encoder, so no `serialiseData` output changes.
