### PR TITLE
Make the SerializeData builtin's encoder opaque to symbolic tools

### DIFF
--- a/PlutusCore/UPLC/BuiltinFunctions/Data.lean
+++ b/PlutusCore/UPLC/BuiltinFunctions/Data.lean
@@ -157,10 +157,20 @@ def mkNilPairData (Vs : List CekValue) : Option CekValue :=
       CekValue.VCon $ Const.ConstPairDataList (PLC.mkNilPairData ())
   | _ => none
 
+/-- Opaque alias of the CBOR encoder, used only by the SerializeData builtin.
+    Declared `opaque` so symbolic tools (e.g. Blaster) treat it as an
+    uninterpreted function instead of unfolding the recursive encoder — whose
+    higher-order recursion (`List.foldlM` closing over `encodeData`) and
+    byte-level `UInt8`/`BitVec` arithmetic they cannot translate. Compiled
+    evaluation (CEK execution, `native_decide`, conformance tests) is
+    unchanged: the provided value IS `encodeData`. `PlutusCore.Cbor.encodeData`
+    itself stays a plain def for direct use and proofs. -/
+opaque encodeDataOpaque (d : PlutusCore.Data.Data) : Option String := PLC.encodeData d
+
 -- Define serializeData
 def serializeData (Vs : List CekValue) : Option CekValue :=
   match Vs with
-  | [CekValue.VCon (Const.Data d)] => (CekValue.VCon ∘ Const.ByteString ∘ ByteString.mk) <$> PLC.encodeData d
+  | [CekValue.VCon (Const.Data d)] => (CekValue.VCon ∘ Const.ByteString ∘ ByteString.mk) <$> encodeDataOpaque d
   | _                              => none
 
 end PlutusCore.UPLC.BuiltinFunctions.Data


### PR DESCRIPTION
Blaster's translation diverges when unfolding encodeData (higher-order recursion through List.foldlM closures) and the byte-level encode paths hit unsupported BitVec/UInt8 arithmetic. Route the builtin through an opaque alias so symbolic execution treats it as an uninterpreted function, mirroring the existing treatment of the hash builtins. Compiled evaluation is unchanged: the opaque's value is encodeData itself, and PlutusCore.Cbor.encodeData stays a plain def.

## Description

Downstream Blaster users currently cannot prove anything about a UPLC validator that calls the `serialiseData` builtin on a non-trivial `Data` value: symbolic translation of the CBOR encoder either never terminates (recursion through `List.foldlM` closures, input-output-hk/Lean-blaster#153) or errors out on the byte-level encoding (`BitVec` unsupported, input-output-hk/Lean-blaster#153). Both are Blaster translation issues; neither is fixable from user code.

This PR applies to the `SerializeData` builtin the treatment every hash builtin already gets (`opaque sha2_256`, `opaque blake2b_256`, … in `PlutusCore/Crypto/Hash/Basic.lean`): an `opaque` alias of the encoder, used only at the builtin dispatch. Symbolic tools then see an uninterpreted function - same input, same output, contents unknown - instead of trying to translate the encoder's body. Compiled evaluation is unchanged: the opaque definition's provided value **is** `encodeData`, so CEK execution, `#eval`, `native_decide`, and the conformance suite all compute exactly the same bytes as before.

Context: we hit this on a production Plutus V3 validator that checks `blake2b_256(serialiseData(config)) == stored_hash`. With this change, theorems that previously spun forever prove in ~6 s, and our 62-theorem suite over the compiled validators is green.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

No evaluation behavior changes, the change only affects what symbolic tools are told about the builtin's encoder. "Bug" here is the practical one: the builtin is unusable under `blaster` today.

## Related Issue

Works around input-output-hk/Lean-blaster#152 (non-terminating translation of `foldlM`-closure recursion) and input-output-hk/Lean-blaster#153 (`BitVec` unsupported). Deliberately not `Fixes`/`Closes`: the proper fixes live in Blaster's translator; this is a pragmatic unblock at the builtin boundary, and it can be reverted (delete the alias) if/when Blaster learns to translate the encoder.

## Changes Made

- Add `opaque encodeDataOpaque (d : Data) : Option String := PLC.encodeData d` next to the builtin definitions in `PlutusCore/UPLC/BuiltinFunctions/Data.lean`, with a doc comment explaining why (mirrors the existing `opaque` hash builtins).
- Switch the `serializeData` builtin dispatch to call `encodeDataOpaque` instead of `PLC.encodeData` directly.
- `PlutusCore.Cbor.encodeData` itself is untouched and stays a plain `def`, every direct caller (the CBOR tests, decode round-trips, anyone proving lemmas about the encoder's definition) is unaffected.

11 lines, one file.

## Testing

- `lake test` against the patch: exit 0, zero failures — expected, since nothing computes differently.
- Downstream (our production use): a 62-theorem suite over compiled Plutus V3 validators, including theorems that exercise `serialiseData` + `blake2b_256` symbolically, all valid; previously the same theorems never returned.
- Concrete-byte sanity: the builtin's output on our configs was cross-checked byte-identical against aiken's `cbor.serialise` via `native_decide` witnesses, demonstrating `opaque` does not affect compiled evaluation.

### Test Coverage

- [ ] Added new tests for new functionality; n/a: no behavioral change to pin; the existing CBOR/conformance tests already cover evaluation, and they pass unchanged.
- [x] All tests pass locally
- [ ] For bug fixes: Added example to `Tests/Issues/` folder; n/a: the failing examples are Blaster-side (they need the `blaster` tactic, which the PlutusCoreBlaster test suite doesn't invoke); they live in input-output-hk/Lean-blaster#152 / #input-output-hk/Lean-blaster#153.

## Documentation

- [ ] README updated (n/a)
- [x] Code comments added/updated (doc comment on the alias states what it is for, what it changes, and what it deliberately does not change)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review performed
- [x] Code is commented
- [ ] Documentation changes; n/a
- [ ] Tests proving the fix;  see Test Coverage above: the "fix" is observable only under the `blaster` tactic; reproducers are attached to the two Lean-blaster issues
- [x] Existing tests pass locally (`lake test`, exit 0)

## Additional Notes

The tradeoff, stated plainly: with the encoder opaque at the builtin, one can no longer prove *symbolic* claims about the builtin's concrete output bytes (e.g. "`serialiseData x` = exactly `0xd879…`" as an SMT fact) the solver only knows "same input ⇒ same output". Three mitigating points:

1. Today that expressiveness is unreachable anyway: input-output-hk/Lean-blaster#152 hangs and input-output-hk/Lean-blaster#153 errors before any such proof gets off the ground, so no currently-provable statement becomes unprovable.
2. Uninterpreted-function congruence is exactly what the common on-chain pattern needs: `blake2b_256(serialiseData(a)) == blake2b_256(serialiseData(b))` chains through equalities without knowing the bytes — the same reasoning already relied on for the (opaque) hashes themselves.
3. Concrete-byte facts remain provable by execution (`native_decide`), which `opaque` does not affect.

One documentation footgun worth a note somewhere (it already exists today for the opaque hashes, this PR just adds one more instance): asking `blaster` to prove a *true concrete* fact about an opaque symbol (e.g. `blake2b_256 "abc" = <the real digest>`) yields a confident-looking `❌ Falsified`, the solver picks an arbitrary interpretation, and the "counterexample" is not real.

Opening as a draft: if you'd rather fix the underlying translation in Blaster than take this shim, we're happy to close in favor of that, we run this patch on a fork in the meantime either way.
