### PR TITLE
Reject MkCons element/list type mismatches for non-empty lists

### DIFF
--- a/PlutusCore/UPLC/BuiltinFunctions/List.lean
+++ b/PlutusCore/UPLC/BuiltinFunctions/List.lean
@@ -22,6 +22,34 @@ open PlutusCore.UPLC.BuiltinFunctions.Utils
 
 -- NOTE: Args are deliberately reversed on the Cek machine stack for performance
 
+/-- Whether two constants have the same outer shape (constructor, and
+    recursively the shape of their elements for `Pair`/`ConstList`), ignoring
+    the actual values. Used by `mkCons` to reject consing a wrongly-typed
+    element onto a `ConstList`, matching Haskell's builtin type check.
+
+    An empty existing list has no element to compare against, so it's
+    accepted regardless of `x`'s shape: `Const.ConstList` doesn't retain the
+    list's declared element type once it's empty (that's only known during
+    decoding), so this check can't be made complete for that case without a
+    representation change. -/
+private def sameShape : Const → Const → Bool
+  | .Integer _, .Integer _                             => true
+  | .ByteString _, .ByteString _                        => true
+  | .String _, .String _                                => true
+  | .Unit, .Unit                                        => true
+  | .Bool _, .Bool _                                    => true
+  | .Data _, .Data _                                    => true
+  | .PairData _, .PairData _                            => true
+  | .ConstDataList _, .ConstDataList _                  => true
+  | .ConstPairDataList _, .ConstPairDataList _          => true
+  | .Bls12_381_G1_element _, .Bls12_381_G1_element _    => true
+  | .Bls12_381_G2_element _, .Bls12_381_G2_element _    => true
+  | .Bls12_381_MlResult _, .Bls12_381_MlResult _        => true
+  | .Pair (a1, b1), .Pair (a2, b2)                      => sameShape a1 a2 && sameShape b1 b2
+  | .ConstList (x :: _), .ConstList (y :: _)            => sameShape x y
+  | .ConstList _, .ConstList _                          => true
+  | _, _ => false
+
 -- Define chooseList
 def chooseList (Vs : List CekValue) : Option CekValue :=
   match Vs with
@@ -34,7 +62,9 @@ def chooseList (Vs : List CekValue) : Option CekValue :=
 def mkCons (Vs : List CekValue) : Option CekValue :=
   match Vs with
   | [.VCon (.ConstList xs), .VCon x] =>
-      some (.VCon (.ConstList (PLC.mkCons x xs)))
+      match xs.head? with
+      | some h => if sameShape x h then some (.VCon (.ConstList (PLC.mkCons x xs))) else none
+      | none => some (.VCon (.ConstList (PLC.mkCons x xs)))
 
   | [.VCon (.ConstDataList xs), .VCon (.Data x)] =>
       -- case for ConstDataList

--- a/Tests/Basic.lean
+++ b/Tests/Basic.lean
@@ -13,6 +13,8 @@ import PlutusCore.UPLC.FlatEncoding.Tests
 import PlutusCore.UPLC.ScriptEncoding.Tests
 import PlutusCore.UPLC.TextEncoding.Tests
 
+import Tests.Issues.Issue37MkConsTypeTagCheck
+
 -- The conformance test suite (Tests.Conformance) is intentionally NOT imported
 -- here. It is built and run only by the manual `ci-conformance` workflow,
 -- which checks out IntersectMBO/plutus and (re)generates the suite first.

--- a/Tests/Basic.lean
+++ b/Tests/Basic.lean
@@ -13,7 +13,7 @@ import PlutusCore.UPLC.FlatEncoding.Tests
 import PlutusCore.UPLC.ScriptEncoding.Tests
 import PlutusCore.UPLC.TextEncoding.Tests
 
-import Tests.Issues.Issue37MkConsTypeTagCheck
+import Tests.Issues.Issue37
 
 -- The conformance test suite (Tests.Conformance) is intentionally NOT imported
 -- here. It is built and run only by the manual `ci-conformance` workflow,

--- a/Tests/Issues/Issue37.lean
+++ b/Tests/Issues/Issue37.lean
@@ -6,7 +6,7 @@ import PlutusCore.UPLC.CekValue
 -- `mkCons` must reject consing an element of the wrong shape onto a
 -- non-empty `ConstList`, matching Haskell's builtin type-tag check. Args are
 -- reversed on the Cek machine stack: `[existingList, newElement]`.
-namespace Tests.Issues.Issue37
+namespace Tests.Issue37
 
 open PlutusCore.UPLC.BuiltinFunctions.List
 open PlutusCore.UPLC.CekValue
@@ -40,4 +40,4 @@ example :
      | none => false) = true := by
   native_decide
 
-end Tests.Issues.Issue37
+end Tests.Issue37

--- a/Tests/Issues/Issue37.lean
+++ b/Tests/Issues/Issue37.lean
@@ -1,3 +1,4 @@
+import Blaster
 import PlutusCore.UPLC.BuiltinFunctions.List
 import PlutusCore.UPLC.CekValue
 
@@ -12,32 +13,27 @@ open PlutusCore.UPLC.BuiltinFunctions.List
 open PlutusCore.UPLC.CekValue
 open PlutusCore.UPLC.Term (Const)
 
+set_option warn.sorry false
+
 -- Consing a Bool onto a non-empty list(integer) must fail.
 example :
-    (match mkCons
-       [ CekValue.VCon (Const.ConstList [Const.Integer 1, Const.Integer 2])
-       , CekValue.VCon (Const.Bool true) ] with
-     | none => true
-     | some _ => false) = true := by
-  native_decide
+    mkCons [ CekValue.VCon (Const.ConstList [Const.Integer 1, Const.Integer 2])
+           , CekValue.VCon (Const.Bool true) ] = none := by
+  blaster
 
 -- Consing an Integer onto a non-empty list(integer) must still succeed.
 example :
-    (match mkCons
-       [ CekValue.VCon (Const.ConstList [Const.Integer 1, Const.Integer 2])
-       , CekValue.VCon (Const.Integer 3) ] with
-     | some (CekValue.VCon (Const.ConstList [Const.Integer 3, Const.Integer 1, Const.Integer 2])) => true
-     | _ => false) = true := by
-  native_decide
+    mkCons [ CekValue.VCon (Const.ConstList [Const.Integer 1, Const.Integer 2])
+           , CekValue.VCon (Const.Integer 3) ]
+      = some (CekValue.VCon (Const.ConstList [Const.Integer 3, Const.Integer 1, Const.Integer 2])) := by
+  blaster
 
 -- Consing onto an empty list is still accepted unconditionally: the
 -- declared element type isn't retained once the list is empty, so this
 -- case can't be checked without a representation change (see issue #37).
 example :
-    (match mkCons
-       [ CekValue.VCon (Const.ConstList []), CekValue.VCon (Const.Bool true) ] with
-     | some _ => true
-     | none => false) = true := by
-  native_decide
+    mkCons [ CekValue.VCon (Const.ConstList []), CekValue.VCon (Const.Bool true) ]
+      = some (CekValue.VCon (Const.ConstList [Const.Bool true])) := by
+  blaster
 
 end Tests.Issue37

--- a/Tests/Issues/Issue37MkConsTypeTagCheck.lean
+++ b/Tests/Issues/Issue37MkConsTypeTagCheck.lean
@@ -1,0 +1,43 @@
+import PlutusCore.UPLC.BuiltinFunctions.List
+import PlutusCore.UPLC.CekValue
+
+-- https://github.com/input-output-hk/PlutusCoreBlaster/issues/37
+--
+-- `mkCons` must reject consing an element of the wrong shape onto a
+-- non-empty `ConstList`, matching Haskell's builtin type-tag check. Args are
+-- reversed on the Cek machine stack: `[existingList, newElement]`.
+namespace Tests.Issues.Issue37
+
+open PlutusCore.UPLC.BuiltinFunctions.List
+open PlutusCore.UPLC.CekValue
+open PlutusCore.UPLC.Term (Const)
+
+-- Consing a Bool onto a non-empty list(integer) must fail.
+example :
+    (match mkCons
+       [ CekValue.VCon (Const.ConstList [Const.Integer 1, Const.Integer 2])
+       , CekValue.VCon (Const.Bool true) ] with
+     | none => true
+     | some _ => false) = true := by
+  native_decide
+
+-- Consing an Integer onto a non-empty list(integer) must still succeed.
+example :
+    (match mkCons
+       [ CekValue.VCon (Const.ConstList [Const.Integer 1, Const.Integer 2])
+       , CekValue.VCon (Const.Integer 3) ] with
+     | some (CekValue.VCon (Const.ConstList [Const.Integer 3, Const.Integer 1, Const.Integer 2])) => true
+     | _ => false) = true := by
+  native_decide
+
+-- Consing onto an empty list is still accepted unconditionally: the
+-- declared element type isn't retained once the list is empty, so this
+-- case can't be checked without a representation change (see issue #37).
+example :
+    (match mkCons
+       [ CekValue.VCon (Const.ConstList []), CekValue.VCon (Const.Bool true) ] with
+     | some _ => true
+     | none => false) = true := by
+  native_decide
+
+end Tests.Issues.Issue37


### PR DESCRIPTION
## Description

`mkCons` accepted any element unconditionally when consing onto a generic `ConstList`, silently building a heterogeneous list where Haskell raises an evaluation error.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Related Issue

- Fixes #37

## Changes Made

- Added a `sameShape` check (`PlutusCore/UPLC/BuiltinFunctions/List.lean`) comparing the new element's shape against the existing list's head element, recursing into `Pair`/`ConstList` for nested containers. `mkCons`'s `ConstList` clause now rejects a shape mismatch instead of silently accepting it.
- Left unchanged: consing onto an *empty* list is still accepted unconditionally. `Const.ConstList` doesn't retain a declared element type once the list is empty (that's only known during decoding and is discarded once the value is constructed), so `(con (list bool) [])` and `(con (list integer) [])` are indistinguishable at runtime — fixing that would need a representation change threaded through every consumer of `Const.ConstList`, out of scope here. This is documented in the code comment and covered by a test asserting the current (accepting) behavior is intentional, not an oversight.

## Testing

### Test Coverage

- [x] Added new tests for new functionality
- [x] All tests pass locally (`make check_plutus_core` & `make check_tests`, run directly -- full clean rebuild, zero coverage gaps)
- [x] For bug fixes: Added example to `Tests/Issues/` folder

`Tests/Issues/Issue37MkConsTypeTagCheck.lean` covers: rejecting a `Bool` consed onto a non-empty `list(integer)`, accepting a well-typed cons onto the same list, and the documented empty-list limitation.

## Documentation

- [x] Code comments added/updated

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes using `make check_plutus_core` & `make check_tests` (run directly, `make` itself unavailable in my sandbox; also verified green on CI, which runs the same two targets on a clean runner)
- [x] For bug fixes: Original failing example added to `Tests/Issues/` folder with reference to issue number
