### PR TITLE
fix(CekMachine): let the SMT backend reduce Frame.CaseScrutinee

### DIFF
--- a/Lemmas/Basic.lean
+++ b/Lemmas/Basic.lean
@@ -16,6 +16,7 @@ import PlutusCore.List.Lemmas
 import PlutusCore.Pair.Lemmas
 import PlutusCore.String.Lemmas
 import PlutusCore.Trace.Lemmas
+import PlutusCore.UPLC.CekMachine.Lemmas
 import PlutusCore.UPLC.FlatEncoding.Lemmas
 import PlutusCore.UPLC.ScriptEncoding.Lemmas
 import PlutusCore.Unit.Lemmas

--- a/PlutusCore/UPLC/CekMachine.lean
+++ b/PlutusCore/UPLC/CekMachine.lean
@@ -9,6 +9,7 @@ import PlutusCore.UPLC.CostModels
 namespace PlutusCore.UPLC.CekMachine
 
 open PlutusCore.Default
+open PlutusCore.Integer (Integer)
 open PlutusCore.UPLC.CekValue
 open PlutusCore.UPLC.Builtins
 open PlutusCore.UPLC.BuiltinFunctions.Evaluate
@@ -56,6 +57,19 @@ def evalBuiltin (semanticsVariant : BuiltinSemanticsVariant) (s : Stack) (b : Bu
 open UPLC.Builtins
 open ExpectedBuiltinArgs
 open BuiltinNotations
+
+/-- Branch selection for `case` on an integer scrutinee: the `i`-th branch of
+    `Ms` when `0 ≤ i < Ms.length`, and `none` otherwise, so that a negative or
+    out-of-range tag is a machine error as in the Plutus reference implementation.
+
+    This is `if 0 ≤ i then Ms[i.toNat]? else none` (see
+    `PlutusCore.UPLC.CekMachine.caseBranch_eq_getElem?`), written as a fold over
+    the branch list so that the tag never appears as a `match` discriminant:
+    `Ms[i.toNat]?` cannot be reduced by the SMT backend when `i` is symbolic,
+    whereas this definition unfolds, for a literal branch list, to a plain chain
+    of integer comparisons. -/
+def caseBranch (Ms : List Term) (i : Integer) : Option Term :=
+  Ms.foldr (fun M rest i => if i = 0 then some M else rest (i - 1)) (fun _ => none) i
 
 def step (semanticsVariant : BuiltinSemanticsVariant) (Sigma : State) : State :=
   match Sigma with
@@ -119,6 +133,12 @@ def step (semanticsVariant : BuiltinSemanticsVariant) (Sigma : State) : State :=
              | M :: Ms => State.Eval (Frame.ConstructorArgument i (Vr :: Vs) Ms ρ :: s) ρ M
              | [] => State.Return s (CekValue.VConstr i (List.reverse (Vr :: Vs)))
 
+         -- NOTE: every alternative below matches at most down to the `Const`
+         -- constructor and binds its payload; any further case analysis on that
+         -- payload is done in the body of the alternative.  This keeps the whole
+         -- `match` reducible as soon as `Vr` is a known `CekValue`/`Const`
+         -- constructor, even when the payload is symbolic, which is what the SMT
+         -- backend needs in order to see through a `case`.
          | Frame.CaseScrutinee Ms ρ =>
              match Vr with
              | CekValue.VConstr i Vs =>
@@ -127,25 +147,23 @@ def step (semanticsVariant : BuiltinSemanticsVariant) (Sigma : State) : State :=
                   | none => State.Error
 
              | CekValue.VCon (Const.Integer n) =>
-                  if 0 ≤ n && n.toNat < Ms.length then
-                    match Ms[n.toNat]? with
-                    | some mi => State.Eval s ρ mi
-                    | none => State.Error
-                  else State.Error
+                  match caseBranch Ms n with
+                  | some mi => State.Eval s ρ mi
+                  | none => State.Error
 
-             | CekValue.VCon (Const.Bool false) =>
-                  if Ms.length == 1 || Ms.length == 2 then
-                    match List.get?Internal Ms 0 with
-                    | some mi => State.Eval s ρ mi
-                    | none => State.Error
-                  else State.Error
-
-             | CekValue.VCon (Const.Bool true) =>
-                  if Ms.length == 2 then
-                    match List.get?Internal Ms 1 with
-                    | some mi => State.Eval s ρ mi
-                    | none => State.Error
-                  else State.Error
+             | CekValue.VCon (Const.Bool b) =>
+                  if b then
+                    if Ms.length == 2 then
+                      match List.get?Internal Ms 1 with
+                      | some mi => State.Eval s ρ mi
+                      | none => State.Error
+                    else State.Error
+                  else
+                    if Ms.length == 1 || Ms.length == 2 then
+                      match List.get?Internal Ms 0 with
+                      | some mi => State.Eval s ρ mi
+                      | none => State.Error
+                    else State.Error
 
              | CekValue.VCon Const.Unit =>
                    if Ms.length == 1 then
@@ -170,50 +188,53 @@ def step (semanticsVariant : BuiltinSemanticsVariant) (Sigma : State) : State :=
                      | none => State.Error
                    else State.Error
 
-             | CekValue.VCon (Const.ConstList (c :: cs)) =>
-                   if Ms.length == 1 || Ms.length == 2 then
-                     let Vs := [CekValue.VCon c, CekValue.VCon (Const.ConstList cs)]
-                     match List.get?Internal Ms 0 with
-                     | some mi => State.Eval (folding Vs s) ρ mi
-                     | none => State.Error
-                   else State.Error
+             | CekValue.VCon (Const.ConstList l) =>
+                   match l with
+                   | c :: cs =>
+                     if Ms.length == 1 || Ms.length == 2 then
+                       let Vs := [CekValue.VCon c, CekValue.VCon (Const.ConstList cs)]
+                       match List.get?Internal Ms 0 with
+                       | some mi => State.Eval (folding Vs s) ρ mi
+                       | none => State.Error
+                     else State.Error
+                   | [] =>
+                     if Ms.length == 2 then
+                       match List.get?Internal Ms 1 with
+                       | some mi => State.Eval s ρ mi
+                       | none => State.Error
+                     else State.Error
 
-             | CekValue.VCon (Const.ConstList []) =>
-                   if Ms.length == 2 then
-                     match List.get?Internal Ms 1 with
-                     | some mi => State.Eval s ρ mi
-                     | none => State.Error
-                   else State.Error
+             | CekValue.VCon (Const.ConstDataList l) =>
+                   match l with
+                   | c :: cs =>
+                     if Ms.length == 1 || Ms.length == 2 then
+                       let Vs := [CekValue.VCon (.Data c), CekValue.VCon (Const.ConstDataList cs)]
+                       match Ms[0]? with
+                       | some mi => State.Eval (folding Vs s) ρ mi
+                       | none => State.Error
+                     else State.Error
+                   | [] =>
+                     if Ms.length == 2 then
+                       match List.get?Internal Ms 1 with
+                       | some mi => State.Eval s ρ mi
+                       | none => State.Error
+                     else State.Error
 
-             | CekValue.VCon (Const.ConstDataList (c :: cs)) =>
-                   if Ms.length == 1 || Ms.length == 2 then
-                     let Vs := [CekValue.VCon (.Data c), CekValue.VCon (Const.ConstDataList cs)]
-                     match Ms[0]? with
-                     | some mi => State.Eval (folding Vs s) ρ mi
-                     | none => State.Error
-                   else State.Error
-
-             | CekValue.VCon (Const.ConstDataList []) =>
-                   if Ms.length == 2 then
-                     match List.get?Internal Ms 1 with
-                     | some mi => State.Eval s ρ mi
-                     | none => State.Error
-                   else State.Error
-
-             | CekValue.VCon (Const.ConstPairDataList (c :: cs)) =>
-                   if Ms.length == 1 || Ms.length == 2 then
-                     let Vs := [CekValue.VCon (.PairData c), CekValue.VCon (Const.ConstPairDataList cs)]
-                     match List.get?Internal Ms 0 with
-                     | some mi => State.Eval (folding Vs s) ρ mi
-                     | none => State.Error
-                   else State.Error
-
-             | CekValue.VCon (Const.ConstPairDataList []) =>
-                   if Ms.length == 2 then
-                     match List.get?Internal Ms 1 with
-                     | some mi => State.Eval s ρ mi
-                     | none => State.Error
-                   else State.Error
+             | CekValue.VCon (Const.ConstPairDataList l) =>
+                   match l with
+                   | c :: cs =>
+                     if Ms.length == 1 || Ms.length == 2 then
+                       let Vs := [CekValue.VCon (.PairData c), CekValue.VCon (Const.ConstPairDataList cs)]
+                       match List.get?Internal Ms 0 with
+                       | some mi => State.Eval (folding Vs s) ρ mi
+                       | none => State.Error
+                     else State.Error
+                   | [] =>
+                     if Ms.length == 2 then
+                       match List.get?Internal Ms 1 with
+                       | some mi => State.Eval s ρ mi
+                       | none => State.Error
+                     else State.Error
 
              | _ => State.Error
 

--- a/PlutusCore/UPLC/CekMachine/Lemmas.lean
+++ b/PlutusCore/UPLC/CekMachine/Lemmas.lean
@@ -1,0 +1,141 @@
+import PlutusCore.UPLC.CekMachine
+
+namespace PlutusCore.UPLC.CekMachine
+
+open PlutusCore.Data (Data)
+open PlutusCore.Default
+open PlutusCore.UPLC.CekValue
+open PlutusCore.UPLC.Term
+
+/-! ## Theorems on the CEK machine. -/
+
+/-! ### `case` branch selection -/
+
+@[simp] theorem caseBranch_nil (i : Int) : caseBranch [] i = none := rfl
+
+@[simp] theorem caseBranch_cons (M : Term) (Ms : List Term) (i : Int) :
+  caseBranch (M :: Ms) i = if i = 0 then some M else caseBranch Ms (i - 1) := rfl
+
+/-- `caseBranch` selects exactly the branch that the `case` rule of the Plutus
+    reference implementation selects for an integer scrutinee: the `i`-th branch
+    when `0 ≤ i` and it exists, an error otherwise. -/
+theorem caseBranch_eq_getElem? (Ms : List Term) (i : Int) :
+  caseBranch Ms i = if 0 ≤ i then Ms[i.toNat]? else none := by
+  induction Ms generalizing i with
+  | nil => simp
+  | cons M Ms ih =>
+    rw [caseBranch_cons]
+    by_cases h : i = 0
+    . subst h; simp
+    . rw [if_neg h, ih]
+      by_cases h0 : 0 ≤ i
+      . have h1 : 0 ≤ i - 1 := by omega
+        have h2 : i.toNat = (i - 1).toNat + 1 := by omega
+        rw [if_pos h1, if_pos h0, h2]
+        simp
+      . have h1 : ¬ (0 ≤ i - 1) := by omega
+        rw [if_neg h1, if_neg h0]
+
+/-! ### `Frame.CaseScrutinee`
+
+    The `Frame.CaseScrutinee` rule is written so that the `match` on the returned
+    value never looks below the `Const` constructor, and so that an integer tag
+    never appears as a `match` discriminant; both are needed for the SMT backend
+    to be able to reduce a `case`.  The theorems below pin the resulting
+    behaviour to the more direct formulation they replace.
+-/
+
+variable (v : BuiltinSemanticsVariant) (Ms : List Term) (ρ : Environment) (s : Stack)
+
+theorem step_case_integer (n : Int) :
+  step v (State.Return (Frame.CaseScrutinee Ms ρ :: s) (CekValue.VCon (Const.Integer n)))
+    = (if 0 ≤ n && n.toNat < Ms.length then
+         match Ms[n.toNat]? with
+         | some mi => State.Eval s ρ mi
+         | none => State.Error
+       else State.Error) := by
+  show (match caseBranch Ms n with
+        | some mi => State.Eval s ρ mi
+        | none => State.Error) = _
+  rw [caseBranch_eq_getElem?]
+  by_cases h0 : 0 ≤ n
+  . by_cases h1 : n.toNat < Ms.length
+    . rw [if_pos h0, if_pos (by simp [h0, h1])]
+    . rw [if_pos h0, if_neg (by simp [h1]), List.getElem?_eq_none (by omega)]
+  . rw [if_neg h0, if_neg (by simp [h0])]
+
+theorem step_case_bool (b : Bool) :
+  step v (State.Return (Frame.CaseScrutinee Ms ρ :: s) (CekValue.VCon (Const.Bool b)))
+    = (match b with
+       | false =>
+         if Ms.length == 1 || Ms.length == 2 then
+           match List.get?Internal Ms 0 with
+           | some mi => State.Eval s ρ mi
+           | none => State.Error
+         else State.Error
+       | true =>
+         if Ms.length == 2 then
+           match List.get?Internal Ms 1 with
+           | some mi => State.Eval s ρ mi
+           | none => State.Error
+         else State.Error) := by
+  cases b <;> rfl
+
+theorem step_case_constList (l : List Const) :
+  step v (State.Return (Frame.CaseScrutinee Ms ρ :: s) (CekValue.VCon (Const.ConstList l)))
+    = (match l with
+       | c :: cs =>
+         if Ms.length == 1 || Ms.length == 2 then
+           match List.get?Internal Ms 0 with
+           | some mi =>
+             State.Eval (step.folding [CekValue.VCon c, CekValue.VCon (Const.ConstList cs)] s) ρ mi
+           | none => State.Error
+         else State.Error
+       | [] =>
+         if Ms.length == 2 then
+           match List.get?Internal Ms 1 with
+           | some mi => State.Eval s ρ mi
+           | none => State.Error
+         else State.Error) := by
+  cases l <;> rfl
+
+theorem step_case_constDataList (l : List Data) :
+  step v (State.Return (Frame.CaseScrutinee Ms ρ :: s) (CekValue.VCon (Const.ConstDataList l)))
+    = (match l with
+       | c :: cs =>
+         if Ms.length == 1 || Ms.length == 2 then
+           match List.get?Internal Ms 0 with
+           | some mi =>
+             State.Eval
+               (step.folding [CekValue.VCon (.Data c), CekValue.VCon (Const.ConstDataList cs)] s) ρ mi
+           | none => State.Error
+         else State.Error
+       | [] =>
+         if Ms.length == 2 then
+           match List.get?Internal Ms 1 with
+           | some mi => State.Eval s ρ mi
+           | none => State.Error
+         else State.Error) := by
+  cases l <;> rfl
+
+theorem step_case_constPairDataList (l : List (Data × Data)) :
+  step v (State.Return (Frame.CaseScrutinee Ms ρ :: s) (CekValue.VCon (Const.ConstPairDataList l)))
+    = (match l with
+       | c :: cs =>
+         if Ms.length == 1 || Ms.length == 2 then
+           match List.get?Internal Ms 0 with
+           | some mi =>
+             State.Eval
+               (step.folding [CekValue.VCon (.PairData c),
+                              CekValue.VCon (Const.ConstPairDataList cs)] s) ρ mi
+           | none => State.Error
+         else State.Error
+       | [] =>
+         if Ms.length == 2 then
+           match List.get?Internal Ms 1 with
+           | some mi => State.Eval s ρ mi
+           | none => State.Error
+         else State.Error) := by
+  cases l <;> rfl
+
+end PlutusCore.UPLC.CekMachine

--- a/PlutusCore/UPLC/CekMachine/Tests.lean
+++ b/PlutusCore/UPLC/CekMachine/Tests.lean
@@ -1,0 +1,128 @@
+import Blaster
+import PlutusCore.UPLC.CekMachine
+import PlutusCore.UPLC.PlutusScript
+import PlutusCore.UPLC.PreProcess
+import PlutusCore.UPLC.Utils
+
+namespace PlutusCore.UPLC.CekMachine.Tests
+
+open PlutusCore.Integer (Integer)
+open PlutusCore.UPLC.CekMachine
+open PlutusCore.UPLC.PlutusScript
+open PlutusCore.UPLC.Term
+open PlutusCore.UPLC.Utils
+
+set_option warn.sorry false
+-- `blaster` closes a `Valid` goal with `admit`
+
+/-- `(con c)`.  NOTE: spelled out because `Term.Const` resolves to the *type*
+    `Const` inside the `PlutusCore.UPLC` namespace. -/
+private def con (c : Const) : Term := .Const c
+
+private def t0 : Term := con (.Integer 10)
+private def t1 : Term := con (.Integer 20)
+private def t2 : Term := con (.Integer 30)
+
+/-! ## `case` branch selection -/
+
+example : caseBranch []       0    = none    := rfl
+example : caseBranch [t0, t1] 0    = some t0 := rfl
+example : caseBranch [t0, t1] 1    = some t1 := rfl
+example : caseBranch [t0, t1] 2    = none    := rfl
+example : caseBranch [t0, t1] (-1) = none    := rfl
+example : caseBranch [t0, t1] (-9) = none    := rfl
+
+/-! ## `case` evaluation
+
+    Which branch a `case` selects, and when it is a machine error, must not
+    depend on how the `Frame.CaseScrutinee` rule is written down.
+-/
+
+private def run (t : Term) : Option Integer :=
+  fromFrameToInt (cekExecuteProgram (Program.Program (Version.Version 1 1 0) t) [] 50)
+
+private def isError (t : Term) : Bool :=
+  match cekExecuteProgram (Program.Program (Version.Version 1 1 0) t) [] 50 with
+  | State.Error => true
+  | _           => false
+
+private def lte (a b : Integer) : Term :=
+  ((Term.Builtin BuiltinFun.LessThanEqualsInteger).Apply (con (.Integer a))).Apply (con (.Integer b))
+
+-- scrutinee is a builtin `Bool`: `False` takes branch 0, `True` takes branch 1,
+-- and `False` is also accepted with a single branch
+example : run ((lte 3 5).Case [t0, t1]) = some 20 := by native_decide
+example : run ((lte 5 3).Case [t0, t1]) = some 10 := by native_decide
+example : run ((lte 5 3).Case [t0])     = some 10 := by native_decide
+example : isError ((lte 3 5).Case [t0])         = true := by native_decide
+example : isError ((lte 3 5).Case [t0, t1, t2]) = true := by native_decide
+example : isError ((lte 5 3).Case [t0, t1, t2]) = true := by native_decide
+example : isError ((lte 5 3).Case [])           = true := by native_decide
+
+-- scrutinee is a constant `Integer`: it indexes the branch list, and a negative
+-- or out-of-range tag is an error
+example : run ((con (.Integer 0)).Case [t0, t1, t2]) = some 10 := by native_decide
+example : run ((con (.Integer 1)).Case [t0, t1, t2]) = some 20 := by native_decide
+example : run ((con (.Integer 2)).Case [t0, t1, t2]) = some 30 := by native_decide
+example : isError ((con (.Integer 3)).Case [t0, t1, t2])    = true := by native_decide
+example : isError ((con (.Integer (-1))).Case [t0, t1, t2]) = true := by native_decide
+example : isError ((con (.Integer 0)).Case [])              = true := by native_decide
+
+-- scrutinee is a constant `Unit`: exactly one branch, taking no arguments
+example : run ((con .Unit).Case [t0]) = some 10 := by native_decide
+example : isError ((con .Unit).Case [])       = true := by native_decide
+example : isError ((con .Unit).Case [t0, t1]) = true := by native_decide
+
+-- scrutinee is a constant list: a cons applies branch 0 to head and tail,
+-- an empty list takes branch 1
+private def intList (cs : List Integer) : Term := con (.ConstList (cs.map Const.Integer))
+
+/-- `(lam h (lam t h))`: keeps the head of the matched list -/
+private def headBranch : Term := Term.Lam "h" (Term.Lam "t" (Term.Var 1))
+
+example : run ((intList [7, 8]).Case [headBranch, t0]) = some 7  := by native_decide
+example : run ((intList [7, 8]).Case [headBranch])     = some 7  := by native_decide
+example : run ((intList []).Case [headBranch, t0])     = some 10 := by native_decide
+example : isError ((intList []).Case [headBranch])             = true := by native_decide
+example : isError ((intList [7, 8]).Case [headBranch, t0, t2]) = true := by native_decide
+
+-- scrutinee is a `constr` term: the constructor tag indexes the branch list
+example : run ((Term.Constr 1 []).Case [t0, t1, t2])     = some 20 := by native_decide
+example : isError ((Term.Constr 3 []).Case [t0, t1, t2]) = true    := by native_decide
+
+/-! ## Regression: `blaster` must see through a `case`
+
+    A `case` whose scrutinee is symbolic used to leave the whole
+    `Frame.CaseScrutinee` match unreduced, which made `blaster` diverge on any
+    program the Scalus compiler emits for PlutusV3.  See
+    `PlutusCore.UPLC.CekMachine.caseBranch`.
+-/
+
+private def script (t : Term) : PlutusScript :=
+  { lang := PlutusLanguage.PlutusV3, script := Program.Program (Version.Version 1 1 0) t }
+
+/-- `(lam x (lam y (case [(builtin lessThanEqualsInteger) x y] y x)))`, i.e. `min x y`
+    the way the Scalus compiler lowers it for PlutusV3. -/
+def minCaseScript : PlutusScript :=
+  script (Term.Lam "x" (Term.Lam "y"
+    ((((Term.Builtin BuiltinFun.LessThanEqualsInteger).Apply (Term.Var 1)).Apply
+        (Term.Var 0)).Case [Term.Var 0, Term.Var 1])))
+
+/-- `(lam x (case x [(con integer 10) (con integer 20)]))`: a `case` on a symbolic
+    integer tag, the shape an ADT match lowers to. -/
+def intCaseScript : PlutusScript :=
+  script (Term.Lam "x" ((Term.Var 0).Case [t0, t1]))
+
+private def oneInteger  (x : Integer)   : List Term := [con (.Integer x)]
+private def twoIntegers (x y : Integer) : List Term := [con (.Integer x), con (.Integer y)]
+
+#prep_uplc minCasePrep minCaseScript twoIntegers 30
+#prep_uplc intCasePrep intCaseScript oneInteger 15
+
+theorem minCase_is_a_lower_bound : ∀ (x y r : Integer),
+  (fromFrameToInt $ minCasePrep.prop x y) = some r → r ≤ x ∧ r ≤ y := by blaster
+
+theorem intCase_selects_a_branch : ∀ (x r : Integer),
+  (fromFrameToInt $ intCasePrep.prop x) = some r → r = 10 ∨ r = 20 := by blaster
+
+end PlutusCore.UPLC.CekMachine.Tests

--- a/Tests/Basic.lean
+++ b/Tests/Basic.lean
@@ -9,6 +9,7 @@ import Cryptograph.Sha3.Sha3_256TestVectors
 
 import PlutusCore.Bitwise.Tests
 import PlutusCore.Cbor.Tests
+import PlutusCore.UPLC.CekMachine.Tests
 import PlutusCore.UPLC.FlatEncoding.Tests
 import PlutusCore.UPLC.ScriptEncoding.Tests
 import PlutusCore.UPLC.TextEncoding.Tests


### PR DESCRIPTION
# fix(CekMachine): let the SMT backend reduce `Frame.CaseScrutinee`

## Problem

`blaster` does not terminate on any PlutusV3 program that uses `case`.

The two programs below both compute `min x y` and were produced by the Scalus
compiler from the same source. The `ifThenElse` one proves in ~1.4 s; the `case`
one never returns.

```
PV11 (case):       (lam x (lam y (case [(builtin lessThanEqualsInteger) x y] y x)))
PV10 (ifThenElse): (lam x (lam y (force (ifThenElse [(builtin lessThanEqualsInteger) x y]
                                                    (delay x) (delay y)))))
```

This blocks every PlutusV3 script: `case` is how PV11 lowers both `Bool`
branching and ADT matching.

## Root cause

Two independent problems in the `Frame.CaseScrutinee` arm of
`CekMachine.step`, both of which leave the arm irreducible for the optimizer.
They are in Blaster's *optimization* phase, not in Z3.

### 1. Splitting `Const.Bool` into two patterns blocks the whole `match`

The arm used to have

```lean
| CekValue.VCon (Const.Bool false) => ...
| CekValue.VCon (Const.Bool true)  => ...
```

Lean compiles that to a decision tree that ends in `Bool.casesOn` on the
constant's payload. Blaster reduces a `match` only when `whnf` can actually
select an alternative (`reduceMatch?` → `commonMatchReduction?` in
`Blaster/Optimize/Rewriting/OptimizeMatch.lean`). A builtin returns
`VCon (Const.Bool <symbolic>)`, so the tree gets stuck at `Bool.casesOn` and no
alternative is selected. The fallback path, normalizing the `match` into an
`ite` chain (`normMatchExpr?` in `NormalizeMatch.lean`), does not apply either:
it requires every pattern to be a closed constructor, a `Nat`/`Int` literal, a
`Nat`/`Int` expression, or a plain variable, and patterns such as
`CekValue.VConstr i Vs` and `CekValue.VCon (Const.Pair p)` are constructor
applications *with* free variables over a non-numeric discriminant.

So the entire 15-alternative `match` survives optimization. `runSteps` is then
distributed over all 15 alternatives (`constMatchPropagation?`), each carrying a
symbolic branch `Term`, and the next `step` is again a stuck `match` on `Term`
(9 constructors). The result is exponential in the remaining step budget.

Evidence, one `step` from the real CEK state, optimizer only
(`Repro/Diag5.lean`, `blaster (only-optimize: 1)`):

```
⊢ ∀ (x y : Int),
    ¬match CekValue.VCon (Const.Bool (Blaster.decide' ¬y < x)) with
      | CekValue.VConstr i Vs => match [Term.Var 0, Term.Var 1].get?Internal i with ...
      | CekValue.VCon (Const.Integer n) =>
          ¬n < Int.ofNat 0 ∧ Int.toNat n < 2 →
            match [Term.Var 0, Term.Var 1].get?Internal (Int.toNat n) with ...
      | CekValue.VCon (Const.Bool false) => False
      | CekValue.VCon (Const.Bool true) => False
      ... 11 more alternatives ...
```

The scrutinee is literally `VCon (Const.Bool …)` and the match is still there.

Minimal isolation (`Repro/Probe2.lean`, both on the real `CekValue`/`Const`):

| shape | optimizer result |
| --- | --- |
| `\| VCon (Const.Bool false) => …` / `\| VCon (Const.Bool true) => …` | whole match survives |
| `\| VCon (Const.Bool b) => if b then … else …` | reduces to `True` |

Only three more CEK steps are needed after this state, and even those three
steps do not finish: 1.25 GB RSS and no result after 4 minutes.

### 2. `Ms[n.toNat]?` is opaque for a symbolic tag

The `Const.Integer` arm indexed the branch list with `Ms[n.toNat]?`, i.e.
`List.get?Internal Ms (Int.toNat n)`. `List.get?Internal` is recursive, and
Blaster unfolds a recursive application only when **every** explicit argument is
a constructor (`isFunRecReduction?` → `allExplicitParamsAreCtor` in
`OptimizeApp.lean`). A symbolic tag is not, so the lookup stays opaque and the
selected branch stays symbolic - the same explosion as above.

This is on the hot path for every ADT match the Scalus compiler emits: the
constructor tag arrives as `fstPair (unConstrData d)`, i.e. as a `Const.Integer`.

Evidence (`Repro/Probe.lean`, `blaster (only-optimize: 1)`):

| shape | optimizer result |
| --- | --- |
| `[t0, t1][i.toNat]?` | residual `[Term.Var 0, Term.Var 1].get?Internal i.toNat` |
| `foldr`-based lookup | reduces to `True` |

### Not a cause: the `VConstr` arm

`case` on a genuine `constr` term already worked, because the tag comes from the
term and is a literal. Confirmed on a Scalus-compiled `List` fold: Valid in
1.66 s before the change.

## The fix

Invariant introduced: **the `match Vr with` in `Frame.CaseScrutinee` never looks
below the `Const` constructor**, and an integer tag is never a `match`
discriminant.

1. New `CekMachine.caseBranch : List Term → Integer → Option Term`, a `foldr`
   over the branch list. For a literal branch list it unfolds to a plain chain
   of integer comparisons; the tag is only ever compared, never matched on.
   The `Const.Integer` arm now uses it instead of the guard + `Ms[n.toNat]?`.
2. `Const.Bool false` / `Const.Bool true` merged into one `Const.Bool b`
   alternative whose body is `if b then … else …`. The length guards
   (`False` accepts 1 or 2 branches, `True` requires exactly 2) are unchanged.
3. `Const.ConstList` / `Const.ConstDataList` / `Const.ConstPairDataList`: the
   cons/nil pattern pairs moved out of the outer `match` into an inner
   `match l with`. Same class of bug, same mechanical rewrite.

No behavioural change is intended, and none is possible in the arms covered by
the lemmas below.

## Why it is semantics-preserving

`PlutusCore/UPLC/CekMachine/Lemmas.lean` proves each restructured arm equal to
the formulation it replaces, with the old right-hand side written out verbatim:

- `step_case_bool`, `step_case_constList`, `step_case_constDataList`,
  `step_case_constPairDataList` - by `cases … <;> rfl`, i.e. the rewrite is
  definitional once the payload is case-split.
- `step_case_integer` - via `caseBranch_eq_getElem?`, which proves
  `caseBranch Ms i = if 0 ≤ i then Ms[i.toNat]? else none`. Negative tags and
  out-of-range tags remain machine errors.

The cost model is untouched: `calculateStepCostr` and
`getBuiltinCostIfExecuted` do not look at the case arm, and every
`budgetMatches` assertion in the conformance suite still passes.

## Before / after

> The `Repro/*.lean` files referenced below are local scratch used during diagnosis and are
> **not part of this PR**. The reproducible artifact in the diff is
> `PlutusCore/UPLC/CekMachine/Tests.lean`, whose two `blaster` proofs diverge on the previous
> code and prove in ~1.6 s on this branch. Happy to attach the scratch files if useful.


Wall-clock for `lake env lean <file>` (each file elaborates the program and runs
`blaster`). "no result" means the run was killed at the stated limit.

| repro | before | after |
| --- | --- | --- |
| `Repro/Baseline.lean` - `ifThenElse`, PV10 | 1.4 s Valid | **1.34 s Valid** |
| `Repro/CaseBlowup.lean` - both theorems | no result after 5 min 30 s | **1.53 s, both Valid** |
| `Repro/Pv11_1.lean` - `case` on builtin `Bool` | no result after 5 min 30 s | **1.23 s Valid** |
| `Repro/Pv11_2.lean` - `case` on builtin `Integer` (Scala `Option` match) | no result after 5 min 30 s | **1.30 s Valid** |
| `Repro/Pv11_3.lean` - `case` on `constr` (List fold) | 1.66 s Valid | **1.35 s Valid** |
| `PlutusCore/UPLC/CekMachine/Tests.lean` - 30 `example`s + 2 proofs | n/a | **1.6 s** |

An earlier, longer run of the 23-step `case` program reached 1.4 GB RSS with no
result after 7 min 22 s, entirely inside `#prep_uplc` (i.e. Blaster's optimizer,
before any SMT query is built).

The `ifThenElse` baseline did not get slower.

## Tests added

`PlutusCore/UPLC/CekMachine/Tests.lean` (imported from `Tests/Basic.lean`, so it
runs under `lake test` / `make check_tests`):

- 6 `rfl` checks on `caseBranch`, including negative and out-of-range tags.
- 24 `native_decide` checks running the CEK machine on `case` programs covering
  every restructured arm and every error case: `Bool` (branch counts 0, 1, 2, 3),
  `Integer` (in range, out of range, negative, empty branch list), `Unit`, a
  constant list (cons, nil, wrong branch counts), and a `constr` term.
- The actual regression guard: two `blaster` proofs, one over `min` written with
  `case` on a builtin `Bool`, one over a `case` on a symbolic integer tag. Both
  diverge on the previous code.

## Verification

```
make check_plutus_core           # lake clean + build PlutusCore, Tests, Lemmas
                                 # + module-coverage check                      -> pass
lake build Tests                 # == lake test                                 -> pass
lake build Tests.Conformance     # 1110 modules from the plutus-conformance corpus
lake env lean Repro/{Baseline,CaseBlowup,Pv11_1,Pv11_2,Pv11_3}.lean
```

Conformance suite: **1110/1110 modules built, `Build completed successfully`**,
against the plutus-conformance corpus from plutus 1.63.0.0.

This includes `Tests.Conformance.Generated.Term.Var`, which failed on the
previous base of this branch. That failure was not caused by this change (it
reproduced identically on the then-current `main`), and it is fixed by #41.
Rebasing onto `main` picks that fix up, so the earlier red conformance run on
this PR is resolved.

The 43 conformance modules that exercise `case` (`term/case` and
`term/constant-case/{bool,integer,list,pair,unit}`) pass.
