### PR TITLE
Add exhaustion-free step iteration and composition lemmas

### DIFF
--- a/Lemmas/Basic.lean
+++ b/Lemmas/Basic.lean
@@ -16,6 +16,7 @@ import PlutusCore.List.Lemmas
 import PlutusCore.Pair.Lemmas
 import PlutusCore.String.Lemmas
 import PlutusCore.Trace.Lemmas
+import PlutusCore.UPLC.CekMachine.Lemmas
 import PlutusCore.UPLC.FlatEncoding.Lemmas
 import PlutusCore.UPLC.ScriptEncoding.Lemmas
 import PlutusCore.Unit.Lemmas

--- a/PlutusCore/UPLC/CekMachine/Lemmas.lean
+++ b/PlutusCore/UPLC/CekMachine/Lemmas.lean
@@ -1,0 +1,125 @@
+import PlutusCore.UPLC.CekMachine
+
+namespace PlutusCore.UPLC.CekMachine
+
+open PlutusCore.Default
+open PlutusCore.UPLC.CekValue (CekValue)
+open PlutusCore.UPLC.Term (Program Term)
+
+/-! ## Fuel-free step iteration
+
+`stepAbs`/`stepN` iterate `step` without fuel, returning the state reached instead of
+`runSteps`'s fuel-exhaustion `Error`, so a run splits into two analyzable pieces. -/
+
+/-- `step`, but a no-op on `Halt`/`Error`, which raw `step` sends to `Error`. -/
+def stepAbs (sv : BuiltinSemanticsVariant) (s : State) : State :=
+  match s with
+  | State.Halt V => State.Halt V
+  | State.Error => State.Error
+  | _ => step sv s
+
+/-- Fuel-free iteration of `stepAbs`. -/
+def stepN (sv : BuiltinSemanticsVariant) (s : State) : Nat → State
+  | 0 => s
+  | (k + 1) => stepN sv (stepAbs sv s) k
+
+@[simp] theorem runSteps_halt (sv : BuiltinSemanticsVariant) (V : CekValue) (n : Nat) :
+    runSteps sv (State.Halt V) n = State.Halt V := by
+  cases n <;> rfl
+
+@[simp] theorem runSteps_error (sv : BuiltinSemanticsVariant) (n : Nat) :
+    runSteps sv State.Error n = State.Error := by
+  cases n <;> rfl
+
+/-- `stepAbs` agrees with `step` off `Halt`/`Error`, and is a no-op on them. -/
+theorem stepAbs_not_halt_error (sv : BuiltinSemanticsVariant) (s : State)
+    (h1 : ∀ V, s ≠ State.Halt V) (h2 : s ≠ State.Error) :
+    stepAbs sv s = step sv s := by
+  unfold stepAbs
+  cases s with
+  | Halt V => exact absurd rfl (h1 V)
+  | Error => exact absurd rfl h2
+  | Eval _ _ _ => rfl
+  | Return _ _ => rfl
+
+/-- One step of `runSteps` folds into one of `stepAbs`, with no hypothesis on `s`. -/
+theorem runSteps_succ (sv : BuiltinSemanticsVariant) (s : State) (k : Nat) :
+    runSteps sv s (k + 1) = runSteps sv (stepAbs sv s) k := by
+  cases s with
+  | Halt V => simp [stepAbs]
+  | Error => simp [stepAbs]
+  | Eval st rho t => rfl
+  | Return st v => rfl
+
+/-- Once halted at `m` steps, still halted at `m + k` steps for any extra fuel `k`. -/
+theorem runSteps_halt_stable (sv : BuiltinSemanticsVariant) (s : State) (V : CekValue)
+    (m k : Nat) (h : runSteps sv s m = State.Halt V) :
+    runSteps sv s (m + k) = State.Halt V := by
+  induction m generalizing s with
+  | zero =>
+      cases s with
+      | Halt V' =>
+          simp only [runSteps] at h
+          cases h
+          simp [runSteps_halt]
+      | Error =>
+          simp only [runSteps] at h
+          injection h
+      | Eval st rho t =>
+          simp only [runSteps] at h
+          injection h
+      | Return st v =>
+          simp only [runSteps] at h
+          injection h
+  | succ n ih =>
+      rw [runSteps_succ] at h
+      have : runSteps sv s (n + 1 + k) = runSteps sv (stepAbs sv s) (n + k) := by
+        have heq : n + 1 + k = (n + k) + 1 := by omega
+        rw [heq, runSteps_succ]
+      rw [this]
+      exact ih (stepAbs sv s) h
+
+/-- Fuel composition, with no side condition. Two properties of `stepAbs` carry it:
+    absorption, which is what makes `runSteps_succ` hold on the terminal states, and the
+    absence of a fuel-exhaustion branch, which is why the prefix yields the state reached
+    where `runSteps sv (runSteps sv s m) n` yields `Error`. -/
+theorem runSteps_add (sv : BuiltinSemanticsVariant) (s : State) (m n : Nat) :
+    runSteps sv s (m + n) = runSteps sv (stepN sv s m) n := by
+  induction m generalizing s with
+  | zero => simp [stepN]
+  | succ k ih =>
+      have heq : k + 1 + n = (k + n) + 1 := by omega
+      rw [heq, runSteps_succ, ih (stepAbs sv s)]
+      rfl
+
+/-- The fuelled machine and the fuel-free iteration agree exactly on halting runs. -/
+theorem runSteps_halt_iff_stepN (sv : BuiltinSemanticsVariant) (s : State) (V : CekValue)
+    (m : Nat) :
+    runSteps sv s m = State.Halt V ↔ stepN sv s m = State.Halt V := by
+  have key : runSteps sv s m = runSteps sv (stepN sv s m) 0 := by
+    simpa using runSteps_add sv s m 0
+  rw [key]
+  cases hst : stepN sv s m with
+  | Halt V' => simp [runSteps]
+  | Error => simp [runSteps]
+  | Eval st rho t => simp [runSteps]
+  | Return st v => simp [runSteps]
+
+/-- A program's result does not depend on how much fuel it was given, past enough. -/
+theorem cekExecuteProgramWithSemanticVariant_halt_stable
+    (sv : BuiltinSemanticsVariant) (p : Program) (params : List Term) (V : CekValue) (n k : Nat)
+    (h : cekExecuteProgramWithSemanticVariant sv p params n = State.Halt V) :
+    cekExecuteProgramWithSemanticVariant sv p params (n + k) = State.Halt V := by
+  cases p with
+  | Program ver body =>
+      simp only [cekExecuteProgramWithSemanticVariant] at h ⊢
+      exact runSteps_halt_stable sv _ V n k h
+
+/-- The same, at the default semantics variant. -/
+theorem cekExecuteProgram_halt_stable
+    (p : Program) (params : List Term) (V : CekValue) (n k : Nat)
+    (h : cekExecuteProgram p params n = State.Halt V) :
+    cekExecuteProgram p params (n + k) = State.Halt V :=
+  cekExecuteProgramWithSemanticVariant_halt_stable default p params V n k h
+
+end PlutusCore.UPLC.CekMachine

--- a/PlutusCore/UPLC/CekMachine/Tests.lean
+++ b/PlutusCore/UPLC/CekMachine/Tests.lean
@@ -1,0 +1,73 @@
+import PlutusCore.UPLC.CekMachine.Lemmas
+
+namespace PlutusCore.UPLC.CekMachine
+
+open PlutusCore.Default
+open PlutusCore.UPLC.CekValue (CekValue)
+
+/-! ## Concrete checks for the fuel-free iteration
+
+`rfl` rather than `native_decide`, since `State` has no `DecidableEq` instance. -/
+
+def testSemanticsVariant : BuiltinSemanticsVariant :=
+  PlutusCore.Default.Internal.BuiltinSemanticsVariant.defaultFunSemanticsVariantB
+
+/-- A constant, which the machine evaluates in exactly two steps. -/
+def testTerm : PlutusCore.UPLC.Term.Term :=
+  PlutusCore.UPLC.Term.Term.Const (PlutusCore.UPLC.Term.Const.Integer 42)
+
+/-- The unevaluated starting state for `testTerm`. -/
+def testStart : State := State.Eval [] [] testTerm
+
+/-- Where `testTerm` ends up. -/
+def testResult : CekValue :=
+  PlutusCore.UPLC.CekValue.CekValue.VCon (PlutusCore.UPLC.Term.Const.Integer 42)
+
+-- `stepN` really iterates. Without these, every check below would pass against a
+-- `stepN` that never stepped.
+example : stepN testSemanticsVariant testStart 1
+    = State.Return [] testResult := rfl
+example : stepN testSemanticsVariant testStart 2
+    = State.Halt testResult := rfl
+
+-- Past the halt it sits still.
+example : stepN testSemanticsVariant testStart 5
+    = State.Halt testResult := rfl
+example (V : CekValue) :
+    stepAbs testSemanticsVariant (State.Halt V) = State.Halt V := rfl
+example : stepAbs testSemanticsVariant State.Error = State.Error := rfl
+
+-- At zero fuel `stepN` is the identity.
+example (s : State) : stepN testSemanticsVariant s 0 = s := rfl
+
+-- Splitting through `runSteps` turns a halting run into an `Error`. Splitting
+-- through `stepN` does not.
+example : runSteps testSemanticsVariant testStart 1 = State.Error := rfl
+example : runSteps testSemanticsVariant testStart 2
+    = State.Halt testResult := rfl
+example :
+    runSteps testSemanticsVariant (runSteps testSemanticsVariant testStart 1) 1
+      = State.Error := rfl
+example :
+    runSteps testSemanticsVariant (stepN testSemanticsVariant testStart 1) 1
+      = State.Halt testResult := rfl
+
+-- The composition lemma at a concrete split.
+example (s : State) :
+    runSteps testSemanticsVariant s (2 + 3)
+      = runSteps testSemanticsVariant (stepN testSemanticsVariant s 2) 3 :=
+  runSteps_add testSemanticsVariant s 2 3
+
+-- The stability theorem is about programs that really do halt, and fuel really does
+-- matter for them: one step short of enough is an `Error`.
+def testProgram : PlutusCore.UPLC.Term.Program :=
+  PlutusCore.UPLC.Term.Program.Program (PlutusCore.UPLC.Term.Version.Version 1 1 0) testTerm
+
+example : cekExecuteProgramWithSemanticVariant testSemanticsVariant testProgram [] 1
+    = State.Error := rfl
+example : cekExecuteProgramWithSemanticVariant testSemanticsVariant testProgram [] 2
+    = State.Halt testResult := rfl
+example : cekExecuteProgramWithSemanticVariant testSemanticsVariant testProgram [] (2 + 7)
+    = State.Halt testResult := rfl
+
+end PlutusCore.UPLC.CekMachine

--- a/Tests/Basic.lean
+++ b/Tests/Basic.lean
@@ -9,6 +9,7 @@ import Cryptograph.Sha3.Sha3_256TestVectors
 
 import PlutusCore.Bitwise.Tests
 import PlutusCore.Cbor.Tests
+import PlutusCore.UPLC.CekMachine.Tests
 import PlutusCore.UPLC.FlatEncoding.Tests
 import PlutusCore.UPLC.ScriptEncoding.Tests
 import PlutusCore.UPLC.TextEncoding.Tests


### PR DESCRIPTION
## Description

Adds an iteration of `step` with no fuel-exhaustion branch (`stepAbs`, `stepN`) and the lemmas relating it to `runSteps`, so a run can be split at an arbitrary point and the two halves analyzed independently. This is a proposal, offered for the maintainers to accept or decline.

`runSteps` cannot be split at an arbitrary point: its `0, _ => Error` branch fires when the prefix runs out of fuel, so `runSteps sv (runSteps sv s m) n` reports `Error` on a run that halts, and the intermediate state is lost. `stepN` has no fuel-exhaustion branch, so the prefix yields the state it reached, and `runSteps_add` then holds with no side condition. It still takes a step count and recurses on it exactly as `runSteps` does, so Lean accepts it for the same reason. The only difference is what happens at zero: `runSteps` reports `Error`, `stepN` hands back the state reached. Nothing existing in the repo is changed.

What prompted this was a downstream Lean development that needs to reason about a long run in halves. Two consequences for this library are included as well, so the addition is not only scaffolding for an outside caller. `runSteps_halt_iff_stepN` says this iteration and the fuelled machine agree exactly on runs that halt, which is what makes `stepN` a faithful way to reason about the machine rather than a convenient approximation. `cekExecuteProgram_halt_stable` says a program's result does not depend on which fuel number the caller picked, past enough of it, which is a property of the public entry point that nothing here previously stated.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality): step iteration with no fuel-exhaustion branch, and its composition lemmas
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test updates: new `CekMachine/Tests.lean`

Purely additive. No existing declaration is modified, so no existing behaviour changes.

## Related Issue

None. Opened directly as a change rather than an issue first, since the addition is small and self-contained enough to judge from the diff.

## Changes Made

- `PlutusCore/UPLC/CekMachine/Lemmas.lean` (new): `stepAbs`, a `step` that is a no-op on `Halt` and `Error` where raw `step` sends both to `Error`, and `stepN`, its iteration with no fuel-exhaustion branch. Then `runSteps_halt` and `runSteps_error` (both `@[simp]`), `stepAbs_not_halt_error`, `runSteps_succ`, `runSteps_halt_stable`, and `runSteps_add`. Finally `runSteps_halt_iff_stepN`, proved from `runSteps_add`, and `cekExecuteProgramWithSemanticVariant_halt_stable` with its default-variant corollary `cekExecuteProgram_halt_stable`.
- `PlutusCore/UPLC/CekMachine/Tests.lean` (new): concrete checks for the two definitions and for a halting program at the entry point.
- `Lemmas/Basic.lean` and `Tests/Basic.lean`: one import line each, so both new modules are inside the build and the file-consideration checks in `check_plutus_core` and `check_tests` cover them.

Note on `runSteps_add`: two properties of `stepAbs` carry it, and they do different jobs. Absorption of `Halt` and `Error` is what makes `runSteps_succ` hold with no hypothesis on the state, since raw `step` sends both terminal states to `Error` and `runSteps` does not. The absence of a fuel-exhaustion branch is separately what makes the split useful, since the prefix yields the state reached rather than `Error`.

## Testing

`CekMachine/Tests.lean` pins the two definitions against observed behaviour. The lemmas are proved, so the checks do not make them more true, they guard against a later edit to `stepAbs` or `stepN` that changes what the lemmas are about.

- `stepN` genuinely iterates: on a constant term it reaches `State.Return` at one step and `Halt` at two. Without these, every other check in the file would pass against a `stepN` that never stepped at all.
- Past the halt it sits still (`stepN` at 5 is still `Halt`), and `stepAbs` is a no-op on both terminal states.
- The contrast that motivates the pair, on a concrete two-step term: `runSteps` at one step of fuel is `Error`, splitting through `runSteps` gives `Error`, and splitting through `stepN` gives `Halt`.
- `runSteps_add` applied at a concrete split, so the split index is exercised and not only quantified over.
- A halting program at the public entry point, so `cekExecuteProgram_halt_stable` is not about an empty hypothesis: at one step short of enough the result is `Error`, at exactly enough it halts, and at seven more it still halts with the same value. The `Error` case is the one that matters, since it shows the fuel argument is really load-bearing.

The state equalities are checked with `rfl`, since a `State` equality has no `Decidable` instance to synthesize. `Bitwise/Tests.lean` is mostly `rfl` too, so this is not a new pattern here. Where a check can be routed through a decidable observation instead, as the conformance suite and #40 both do, `native_decide` would work, and I am happy to restate them that way if you prefer it.

`make check_plutus_core` and `make check_tests` both pass locally with zero errors (289 jobs for `check_tests`). The `Tests` build carries a pre-existing `sorry` warning from `PlutusCore/String/Lemmas.lean`, unrelated to this change.

On reduction shape, since a new definition the SMT backend may traverse is a fair thing to ask about: `stepAbs` adds a match on `State`, and I checked that this does not obstruct the solver. Both `runSteps svp (State.Halt V) n = State.Halt V` and `stepAbs svp (State.Halt V) = State.Halt V` discharge under `by blaster` with no errors. I did not measure the per-goal cost against a baseline, so I can say the extra match is not an obstruction but not that it is free. If the shape is wrong for how you want the backend to see the machine, say so and I will restate the definitions.

### Test Coverage

- [x] Added new tests for new functionality
- [ ] Updated existing tests
- [x] All tests pass locally
- [ ] For bug fixes: Added example to `Tests/Issues/` folder (n/a, not a bug fix)

## Documentation

- [ ] README updated (n/a)
- [x] Code comments added/updated (docstrings on the definitions and the substantive lemmas, and the reason `rfl` is used stated in the test file header)
- [ ] Doc comments added for new optimization/rewritting rules (n/a)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Added tests that prove the new behaviour
- [x] `make check_plutus_core` and `make check_tests` pass locally

## Additional Notes

Two open PRs touch the same ground, and both should probably land first.

- #40 touches all four files this PR does, and creates both `CekMachine/Lemmas.lean` and `CekMachine/Tests.lean`. Happy to rebase onto it, or to fold these declarations into its versions of those files, whichever you prefer.
- #34 adds a `ProtocolVersion` parameter to `step` and `runSteps`. Everything here is built on those, so all of it needs re-signing if that lands. Also happy to rebase onto it.

Sequence this however suits you. If none of this is wanted, closing it costs nothing.

